### PR TITLE
feat: Add CLI interface with argument parsing and backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,38 @@ Run the application to start with taskbar icon:
 - Notifications appear when timer expires
 - Icon changes color to indicate active/inactive state (gray=idle, green=active)
 
+## Command-line mode
+
+The program can be run from the command line with arguments:
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--duration` | `-d` | Minutes to prevent sleep (positive integer; ≤0 = indefinite) |
+| `--interval` | `-i` | Seconds between refreshes (default: 20) |
+| `--prevent-display` | `-p` | Also keep display awake |
+| `--away-mode` | `-a` | Enable away mode (hardware‑dependent) |
+| `--verbose` | `-v` | Print detailed status on each refresh |
+| `--tray` | `-t` | Launch the system‑tray GUI (default if no arguments) |
+
+**Entry points:**
+- `python -m nosleep [ARGS]` (run from project root directory)
+- `python app.py [ARGS]` (run from inside the `nosleep` folder)
+
+**Examples:**
+
+```bash
+# Run for 30 minutes, refresh every 10 seconds, keep display awake
+python -m nosleep --duration 30 --interval 10 --prevent-display
+
+# Run indefinitely with away mode enabled, verbose logging
+python -m nosleep --away-mode --verbose
+
+# Start the tray GUI (same as running without arguments)
+python -m nosleep --tray
+```
+
+**Default behavior:** If no arguments are given, the program starts in tray mode, preserving backward compatibility.
+
 ## API
 ```python
 from nosleep import NoSleep

--- a/__main__.py
+++ b/__main__.py
@@ -3,7 +3,94 @@
 Entry point for nosleep module
 """
 
+import sys
+import argparse
+import logging
+from .core import NoSleep
 from .tray import run_tray
 
+
+def run_cli():
+    """Run nosleep from command line with arguments"""
+    parser = argparse.ArgumentParser(
+        description="Prevent Windows from sleeping using SetThreadExecutionState API",
+        epilog="Example: python -m nosleep --duration 30 --prevent-display"
+    )
+    
+    # Duration argument
+    parser.add_argument(
+        "--duration", "-d",
+        type=int,
+        help="Duration in minutes to prevent sleep (positive integer, 0 or negative = indefinite)"
+    )
+    
+    # Interval argument
+    parser.add_argument(
+        "--interval", "-i",
+        type=int,
+        default=20,
+        help="Interval in seconds to refresh sleep prevention (default: 20)"
+    )
+    
+    # Flags
+    parser.add_argument(
+        "--prevent-display", "-p",
+        action="store_true",
+        help="Also prevent display from sleeping"
+    )
+    
+    parser.add_argument(
+        "--away-mode", "-a",
+        action="store_true",
+        help="Enable away mode (requires compatible hardware)"
+    )
+    
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Print detailed status on every refresh"
+    )
+    
+    # Tray mode
+    parser.add_argument(
+        "--tray", "-t",
+        action="store_true",
+        help="Start in system tray mode (default if no arguments provided)"
+    )
+    
+    args = parser.parse_args()
+    
+    # Convert non-positive duration to None (indefinite)
+    if args.duration is not None and args.duration <= 0:
+        args.duration = None
+    
+    # If tray flag is set or no arguments provided, run tray mode
+    if args.tray or len(sys.argv) == 1:
+        return run_tray()
+    
+    # Otherwise run CLI mode with provided arguments
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+    
+    ns = NoSleep()
+    try:
+        ns.run(
+            duration_minutes=args.duration,
+            interval_seconds=args.interval,
+            prevent_display=args.prevent_display,
+            away_mode=args.away_mode,
+            verbose=args.verbose
+        )
+        return 0
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+        return 0
+    except Exception as e:
+        logging.error(f"Error: {e}")
+        return 1
+
+
 if __name__ == "__main__":
-    run_tray()
+    sys.exit(run_cli())

--- a/app.py
+++ b/app.py
@@ -7,6 +7,87 @@ Main application entry point
 import sys
 import os
 import traceback
+import argparse
+import logging
+
+
+def parse_args():
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser(
+        description="Prevent Windows from sleeping using SetThreadExecutionState API",
+        epilog="Example: python app.py --duration 30 --prevent-display"
+    )
+    
+    # Duration argument
+    parser.add_argument(
+        "--duration", "-d",
+        type=int,
+        help="Duration in minutes to prevent sleep (positive integer, 0 or negative = indefinite)"
+    )
+    
+    # Interval argument
+    parser.add_argument(
+        "--interval", "-i",
+        type=int,
+        default=20,
+        help="Interval in seconds to refresh sleep prevention (default: 20)"
+    )
+    
+    # Flags
+    parser.add_argument(
+        "--prevent-display", "-p",
+        action="store_true",
+        help="Also prevent display from sleeping"
+    )
+    
+    parser.add_argument(
+        "--away-mode", "-a",
+        action="store_true",
+        help="Enable away mode (requires compatible hardware)"
+    )
+    
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Print detailed status on every refresh"
+    )
+    
+    # Tray mode
+    parser.add_argument(
+        "--tray", "-t",
+        action="store_true",
+        help="Start in system tray mode (default if no arguments provided)"
+    )
+    
+    return parser.parse_args()
+
+
+def run_cli(args):
+    """Run nosleep from command line with arguments"""
+    from nosleep.core import NoSleep
+    
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+    
+    ns = NoSleep()
+    try:
+        ns.run(
+            duration_minutes=args.duration,
+            interval_seconds=args.interval,
+            prevent_display=args.prevent_display,
+            away_mode=args.away_mode,
+            verbose=args.verbose
+        )
+        return 0
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+        return 0
+    except Exception as e:
+        logging.error(f"Error: {e}")
+        return 1
+
 
 def main_wrapper():
     """Wrapper to handle import errors and display helpful messages"""
@@ -22,9 +103,20 @@ def main_wrapper():
 
         # Import the tray function from the nosleep package
         from nosleep.tray import run_tray
-
-        # Run the tray function
-        return run_tray()
+        
+        # Parse command line arguments
+        args = parse_args()
+        
+        # Convert non-positive duration to None (indefinite)
+        if args.duration is not None and args.duration <= 0:
+            args.duration = None
+        
+        # If tray flag is set or no arguments provided, run tray mode
+        if args.tray or len(sys.argv) == 1:
+            return run_tray()
+        
+        # Otherwise run CLI mode with provided arguments
+        return run_cli(args)
 
     except ImportError as e:
         print(f"Import Error: {e}", file=sys.stderr)
@@ -55,6 +147,7 @@ def main_wrapper():
         except:
             pass
         return 1
+
 
 if __name__ == "__main__":
     sys.exit(main_wrapper())

--- a/core.py
+++ b/core.py
@@ -79,7 +79,7 @@ class NoSleep:
         """Run nosleep for specified duration or indefinitely with regular refresh
 
         Args:
-            duration_minutes: Number of minutes to run (None = indefinitely)
+            duration_minutes: Number of minutes to run (positive integer, or None for indefinitely)
             interval_seconds: Interval in seconds to refresh sleep prevention state
             prevent_display: Also prevent display from sleeping
             away_mode: Enable away mode
@@ -91,7 +91,7 @@ class NoSleep:
         logging.info("nosleep started - preventing system sleep")
         print("Press Ctrl+C to stop and allow sleep")
 
-        if duration_minutes:
+        if duration_minutes is not None and duration_minutes > 0:
             end_time = self.start_time + timedelta(minutes=duration_minutes)
             logging.info(f"Will run for {duration_minutes} minutes (until {end_time.strftime('%H:%M:%S')})")
 
@@ -138,7 +138,7 @@ class NoSleep:
                 time.sleep(interval_seconds)
 
                 # Check if duration has elapsed
-                if duration_minutes and datetime.now() >= end_time:
+                if duration_minutes is not None and duration_minutes > 0 and datetime.now() >= end_time:
                     logging.info(f"Duration reached ({duration_minutes} minutes). Stopping...")
                     break
 


### PR DESCRIPTION
## Summary
- Add CLI argument parsing to __main__.py and app.py
- Support duration, interval, prevent-display, away-mode, verbose, and tray flags
- Default behavior (no args) launches tray mode for backward compatibility
- Update core.py to handle indefinite durations (None or non-positive)
- Update README.md with command-line usage documentation

## Changes
- `__main__.py`: Added argparse-based CLI with fallback to tray mode
- `app.py`: Updated to parse CLI arguments and choose between CLI and tray mode
- `core.py`: Modified to properly handle None or non-positive duration values
- `README.md`: Added command-line usage section with examples

Closes #11