### PR TITLE
feat: release CI, version injection, About dialog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install MinGW cross-compiler
+        run: sudo apt-get update && sudo apt-get install -y mingw-w64
+
+      - name: Build
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          make CC=x86_64-w64-mingw32-gcc RC=x86_64-w64-mingw32-windres VERSION=$VERSION
+
+      - name: Rename executable
+        run: mv bin/nosleep.exe nosleep-${{ github.ref_name }}.exe
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: nosleep-*.exe

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 # Makefile for nosleep C migration
 # Uses MinGW gcc on Windows
+# VERSION can be overridden on command line: make VERSION=2.2.0
+
+VERSION ?= 0.0.0
 
 CC = gcc
-CFLAGS = -std=c99 -Wall -Wextra -O2 -Isrc
+RC = windres
+CFLAGS = -std=c99 -Wall -Wextra -O2 -Isrc -DVERSION_STR=\"$(VERSION)\"
 LDFLAGS = -mwindows -luser32 -lkernel32 -lgdi32 -lpowrprof -ladvapi32
+
+Comma := ,
+VERSION_COMMA := $(subst .,$(Comma),$(VERSION))
+VERSION_COMMA := $(VERSION_COMMA),0
 
 SRCDIR = src
 OBJDIR = obj
@@ -25,7 +33,8 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(RESOURCE_OBJ): $(SRCDIR)/resources.rc | $(OBJDIR)
-	windres $< -o $@
+	sed 's/@VERSION_COMMA@/$(VERSION_COMMA)/g; s/@VERSION_STRING@/$(VERSION)/g' $(SRCDIR)/resources.rc > $(OBJDIR)/resources_built.rc
+	$(RC) --include-dir $(SRCDIR) -i $(OBJDIR)/resources_built.rc -o $@
 
 $(OBJDIR):
 	mkdir -p $(OBJDIR)

--- a/src/resources.rc
+++ b/src/resources.rc
@@ -6,8 +6,8 @@ IDI_APPICON ICON "../no-sleeping_9260684.ico"
 
 // Version info (optional)
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION     1,0,0,0
-PRODUCTVERSION  1,0,0,0
+FILEVERSION     @VERSION_COMMA@
+PRODUCTVERSION  @VERSION_COMMA@
 FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
 FILEFLAGS       0
 FILEOS          VOS_NT_WINDOWS32
@@ -20,12 +20,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "nosleep"
             VALUE "FileDescription", "Prevent Windows from sleeping"
-            VALUE "FileVersion", "1.0.0.0"
+            VALUE "FileVersion", "@VERSION_STRING@.0"
             VALUE "InternalName", "nosleep"
-            VALUE "LegalCopyright", "MIT License"
+            VALUE "LegalCopyright", "GPL v3"
             VALUE "OriginalFilename", "nosleep.exe"
             VALUE "ProductName", "nosleep"
-            VALUE "ProductVersion", "1.0.0.0"
+            VALUE "ProductVersion", "@VERSION_STRING@.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/tray.c
+++ b/src/tray.c
@@ -2455,13 +2455,16 @@ LRESULT CALLBACK tray_window_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPa
                     DestroyWindow(hwnd);
                     break;
                 case IDM_ABOUT:
-                    MessageBox(NULL,
-                        "nosleep v1.0.0\n"
-                        "Prevent Windows from sleeping using SetThreadExecutionState API\n\n"
+                {
+                    char about_text[512];
+                    snprintf(about_text, sizeof(about_text),
+                        "nosleep v" VERSION_STR "\n\n"
+                        "Prevent Windows from sleeping using\n"
+                        "SetThreadExecutionState API\n\n"
                         "License: GPL v3\n"
-                        "Copyright \xA9 2024-2026",
-                        "About nosleep",
-                        MB_OK | MB_ICONINFORMATION);
+                        "Copyright \xA9 2024-2026");
+                    MessageBox(hwnd, about_text, "About nosleep", MB_OK | MB_ICONINFORMATION);
+                }
                     break;
                 case IDM_TOGGLE_SLEEP_AFTER_TIMEOUT:
                     // Backward compatibility: toggle between SLEEP and NONE


### PR DESCRIPTION
## Changes

1. **GitHub Actions release workflow** — triggered on \*\ tags, cross-compiles with \mingw-w64\, outputs \
osleep-vx.x.x.exe\ as release asset
2. **Version injection** — \Makefile\ accepts \VERSION\ parameter, injects via \-DVERSION_STR\ and \sed\/\windres\ substitution into \.exe\ metadata
3. **About dialog** — now reads version from build-time \VERSION_STR\ instead of hardcoded \1.0.0\

## Commands

- Local build: \make VERSION=2.2.0\
- Release: push tag \2.2.0\ → auto-builds