### PR TITLE
fix: make CURRENT_VERSION use build-injected VERSION_STR + add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+run-name: CI ${{ github.ref_name }}
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install MinGW cross-compiler
+        run: sudo apt-get update && sudo apt-get install -y mingw-w64
+
+      - name: Build
+        run: make CC=x86_64-w64-mingw32-gcc RC=x86_64-w64-mingw32-windres
+
+      - name: Verify binary exists
+        run: |
+          if [ -f bin/nosleep.exe ]; then
+            echo "Binary successfully built: bin/nosleep.exe"
+            file bin/nosleep.exe
+          else
+            echo "ERROR: Binary not found"
+            exit 1
+          fi

--- a/src/constants.h
+++ b/src/constants.h
@@ -18,6 +18,11 @@
 #define ES_AWAYMODE_REQUIRED 0x00000040
 #endif
 
-#define CURRENT_VERSION "1.0.0"
+// VERSION_STR is injected by build system (e.g., -DVERSION_STR=\"1.2.3\")
+// Fallback when not compiled with VERSION_STR defined
+#ifndef VERSION_STR
+#define VERSION_STR "1.0.0"
+#endif
+#define CURRENT_VERSION VERSION_STR
 
 #endif // CONSTANTS_H

--- a/test_ci_cd_workflows.sh
+++ b/test_ci_cd_workflows.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Test: CI/CD workflow files are valid and well-structured
+
+set -euo pipefail
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+
+# === Test 1: Check workflow files exist ===
+if [ -f ".github/workflows/release.yml" ]; then
+    pass "release.yml exists"
+else
+    fail "release.yml is missing"
+fi
+
+if [ -f ".github/workflows/ci.yml" ]; then
+    pass "ci.yml exists"
+else
+    fail "ci.yml is missing"
+fi
+
+# === Test 2: Basic YAML structure check ===
+for f in .github/workflows/*.yml; do
+    if head -1 "$f" | grep -q "^name:" 2>/dev/null; then
+        pass "Basic YAML check: $f has name field"
+    else
+        # Try with CRLF tolerance
+        if head -1 "$f" | grep -q "name:" 2>/dev/null; then
+            pass "Basic YAML check: $f has name field (CRLF)"
+        else
+            fail "Basic YAML check: $f missing name field"
+        fi
+    fi
+done
+
+# Test run-name field
+for f in .github/workflows/*.yml; do
+    if grep -q "run-name:" "$f" 2>/dev/null; then
+        pass "Basic YAML check: $f has run-name field"
+    else
+        fail "Basic YAML check: $f missing run-name field"
+    fi
+done
+
+# === Test 3: release.yml has correct structure ===
+if grep -q "on:" .github/workflows/release.yml; then
+    pass "release.yml has 'on:' trigger"
+else
+    fail "release.yml missing 'on:' trigger"
+fi
+
+# Check for v* tag trigger in the file (handling CRLF)
+if grep -c "v\*" .github/workflows/release.yml > /dev/null 2>&1; then
+    pass "release.yml triggers on v* tags"
+else
+    fail "release.yml does not trigger on v* tags"
+fi
+
+if grep -q "VERSION=" .github/workflows/release.yml; then
+    pass "release.yml injects VERSION during build"
+else
+    fail "release.yml missing VERSION injection"
+fi
+
+# === Test 4: ci.yml has correct structure ===
+if grep -q "on:" .github/workflows/ci.yml; then
+    pass "ci.yml has 'on:' trigger"
+else
+    fail "ci.yml missing 'on:' trigger"
+fi
+
+# Check ci.yml has push/pull_request triggers
+if grep -q "push:" .github/workflows/ci.yml; then
+    pass "ci.yml triggers on push"
+else
+    fail "ci.yml missing push trigger"
+fi
+
+if grep -q "pull_request:" .github/workflows/ci.yml; then
+    pass "ci.yml triggers on pull_request"
+else
+    fail "ci.yml missing pull_request trigger"
+fi
+
+# Check ci.yml has build step
+if grep -q "make" .github/workflows/ci.yml; then
+    pass "ci.yml has make build step"
+else
+    fail "ci.yml missing make build step"
+fi
+
+# === Summary ===
+echo "---"
+echo "Total: $((PASS+FAIL)) | Pass: $PASS | Fail: $FAIL"
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/test_version_replacement.sh
+++ b/test_version_replacement.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Test: Version replacement works correctly during CD build
+# This tests that CURRENT_VERSION uses VERSION_STR from compiler flags
+
+set -euo pipefail
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+
+# Create a temp dir
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+# Copy constants.h (with our fix) to temp dir and test compilation
+cp src/constants.h "$TMPDIR/constants.h"
+
+# === Test 1: With VERSION_STR defined, CURRENT_VERSION should match it ===
+cat > "$TMPDIR/test_version_define.c" << 'EOF'
+#include "constants.h"
+#include <stdio.h>
+int main() {
+    printf("%s", CURRENT_VERSION);
+    return 0;
+}
+EOF
+
+if gcc -DVERSION_STR='"2.0.0"' -I"$TMPDIR" -o "$TMPDIR/test_define" "$TMPDIR/test_version_define.c"; then
+    RESULT=$("$TMPDIR/test_define")
+    if [ "$RESULT" = "2.0.0" ]; then
+        pass "With VERSION_STR defined, CURRENT_VERSION equals VERSION_STR"
+    else
+        fail "Expected '2.0.0' but got '$RESULT'"
+    fi
+else
+    fail "Test program with VERSION_STR defined failed to compile"
+fi
+
+# === Test 2: Without VERSION_STR, CURRENT_VERSION should use default fallback ===
+cat > "$TMPDIR/test_version_nodef.c" << 'EOF'
+#include "constants.h"
+#include <stdio.h>
+int main() {
+    printf("%s", CURRENT_VERSION);
+    return 0;
+}
+EOF
+
+if gcc -I"$TMPDIR" -o "$TMPDIR/test_nodef" "$TMPDIR/test_version_nodef.c"; then
+    RESULT=$("$TMPDIR/test_nodef")
+    if [ "$RESULT" = "1.0.0" ]; then
+        pass "Without VERSION_STR, CURRENT_VERSION uses default fallback '1.0.0'"
+    else
+        fail "Expected '1.0.0' but got '$RESULT'"
+    fi
+else
+    fail "Test program without VERSION_STR failed to compile"
+fi
+
+# === Summary ===
+echo "---"
+echo "Total: $((PASS+FAIL)) | Pass: $PASS | Fail: $FAIL"
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What this PR does

### Before this PR:
1. The release workflow (release.yml) passes the tag version to make, and the Makefile injects `-DVERSION_STR=\"\"` as a compiler flag. However, the code in tray.c uses `CURRENT_VERSION` which was hardcoded to `"1.0.0"`, so the in-app displayed version always showed 1.0.0 regardless of the release tag.
2. There was no CI workflow for basic build verification on push/PR.

### After this PR:
1. `CURRENT_VERSION` is now defined as `VERSION_STR` (the build-injected value), with a fallback to `"1.0.0"` when the compiler flag is absent. This means:
   - Release builds: version tag (e.g., v2.1.0) is automatically embedded in the binary
   - Local builds: fallback "1.0.0" or whatever VERSION is set via make
2. A basic CI workflow (ci.yml) builds the project and verifies the binary exists on every push and pull_request.

### Type of change
fix, ci

### Breaking changes (if any)
None