### PR TITLE
feat: tab-based settings with notification groups and auto-update download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION ?= 0.0.0
 CC = gcc
 RC = windres
 CFLAGS = -std=c99 -Wall -Wextra -O2 -Isrc -DVERSION_STR=\"$(VERSION)\"
-LDFLAGS = -mwindows -luser32 -lkernel32 -lgdi32 -lpowrprof -ladvapi32 -lwinhttp
+LDFLAGS = -mwindows -luser32 -lkernel32 -lgdi32 -lpowrprof -ladvapi32 -lwinhttp -lcomctl32
 
 Comma := ,
 VERSION_COMMA := $(subst .,$(Comma),$(VERSION))

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SRCDIR = src
 OBJDIR = obj
 BINDIR = bin
 
-SOURCES = $(SRCDIR)/core.c $(SRCDIR)/tray.c $(SRCDIR)/main.c
+SOURCES = $(SRCDIR)/core.c $(SRCDIR)/tray.c $(SRCDIR)/main.c $(SRCDIR)/notify_groups.c $(SRCDIR)/updater.c
 OBJECTS = $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
 RESOURCE_OBJ = $(OBJDIR)/resources.o
 TARGET = $(BINDIR)/nosleep.exe

--- a/src/notify_groups.c
+++ b/src/notify_groups.c
@@ -1,0 +1,299 @@
+// Notification groups implementation for nosleep
+#include "notify_groups.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Human-readable names for each notification event
+const char* NOTIFY_EVENT_NAMES[NOTIFY_EVENT_COUNT] = {
+    "Application started",
+    "Session started",
+    "Session stopped",
+    "Timer expired",
+    "Error occurred",
+    "Countdown cancelled",
+    "Update available",
+    "Update check failed",
+    "Sleep detected",
+    "Action failed"
+};
+
+// Default event masks (bit N = 1 means event N is enabled)
+// All events: all bits set
+static const unsigned int DEFAULT_MASK_ALL = 0xFFFFFFFF;
+
+// Critical only: only errors and failures
+static const unsigned int DEFAULT_MASK_CRITICAL = 
+    (1 << NOTIFY_EVENT_ERROR) | 
+    (1 << NOTIFY_EVENT_UPDATE_CHECK_FAILED) | 
+    (1 << NOTIFY_EVENT_ACTION_FAILED);
+
+// None: no events
+static const unsigned int DEFAULT_MASK_NONE = 0;
+
+// Initialize default groups
+static void init_default_groups(NotifyGroupManager* mgr) {
+    mgr->count = 3;
+    mgr->active_index = 0;
+    
+    // Default group 0: All notifications
+    strncpy(mgr->groups[0].name, "All notifications", MAX_GROUP_NAME - 1);
+    mgr->groups[0].name[MAX_GROUP_NAME - 1] = '\0';
+    mgr->groups[0].event_mask = DEFAULT_MASK_ALL;
+    mgr->groups[0].is_default = true;
+    
+    // Default group 1: Critical only
+    strncpy(mgr->groups[1].name, "Critical only", MAX_GROUP_NAME - 1);
+    mgr->groups[1].name[MAX_GROUP_NAME - 1] = '\0';
+    mgr->groups[1].event_mask = DEFAULT_MASK_CRITICAL;
+    mgr->groups[1].is_default = true;
+    
+    // Default group 2: None
+    strncpy(mgr->groups[2].name, "None", MAX_GROUP_NAME - 1);
+    mgr->groups[2].name[MAX_GROUP_NAME - 1] = '\0';
+    mgr->groups[2].event_mask = DEFAULT_MASK_NONE;
+    mgr->groups[2].is_default = true;
+}
+
+void notify_groups_init(NotifyGroupManager* mgr) {
+    if (!mgr) return;
+    
+    memset(mgr, 0, sizeof(NotifyGroupManager));
+    
+    // Try to load from registry first
+    notify_groups_load(mgr);
+    
+    // If no groups found in registry, initialize defaults
+    if (mgr->count == 0) {
+        init_default_groups(mgr);
+    }
+}
+
+NotifyGroup* notify_groups_get_active(NotifyGroupManager* mgr) {
+    if (!mgr || mgr->active_index < 0 || mgr->active_index >= mgr->count) {
+        return NULL;
+    }
+    return &mgr->groups[mgr->active_index];
+}
+
+bool notify_groups_set_active(NotifyGroupManager* mgr, int index) {
+    if (!mgr || index < 0 || index >= mgr->count) {
+        return false;
+    }
+    mgr->active_index = index;
+    return true;
+}
+
+bool notify_groups_should_show(NotifyGroupManager* mgr, NotifyEventId event_id) {
+    if (!mgr) return true; // Default: show everything
+    
+    NotifyGroup* active = notify_groups_get_active(mgr);
+    if (!active) return true;
+    
+    if (event_id < 0 || event_id >= NOTIFY_EVENT_COUNT) {
+        return true; // Unknown events are shown
+    }
+    
+    return (active->event_mask & (1 << event_id)) != 0;
+}
+
+int notify_groups_add(NotifyGroupManager* mgr, const char* name, unsigned int event_mask) {
+    if (!mgr || !name || mgr->count >= MAX_NOTIFY_GROUPS) {
+        return -1;
+    }
+    
+    // Reject empty names
+    if (name[0] == '\0') {
+        return -1;
+    }
+    
+    int index = mgr->count;
+    strncpy(mgr->groups[index].name, name, MAX_GROUP_NAME - 1);
+    mgr->groups[index].name[MAX_GROUP_NAME - 1] = '\0';
+    mgr->groups[index].event_mask = event_mask;
+    mgr->groups[index].is_default = false;
+    mgr->count++;
+    
+    return index;
+}
+
+bool notify_groups_remove(NotifyGroupManager* mgr, int index) {
+    if (!mgr || index < 0 || index >= mgr->count) return false;
+    if (mgr->groups[index].is_default) return false; // Cannot delete defaults
+    
+    // Shift remaining groups
+    for (int i = index; i < mgr->count - 1; i++) {
+        memcpy(&mgr->groups[i], &mgr->groups[i + 1], sizeof(NotifyGroup));
+    }
+    mgr->count--;
+    
+    // Adjust active index if needed
+    if (mgr->active_index >= mgr->count) {
+        mgr->active_index = mgr->count - 1;
+    } else if (mgr->active_index > index) {
+        mgr->active_index--;
+    }
+    
+    return true;
+}
+
+bool notify_groups_update(NotifyGroupManager* mgr, int index, const char* name, unsigned int event_mask) {
+    if (!mgr || !name || index < 0 || index >= mgr->count) return false;
+    if (name[0] == '\0') return false;
+    
+    strncpy(mgr->groups[index].name, name, MAX_GROUP_NAME - 1);
+    mgr->groups[index].name[MAX_GROUP_NAME - 1] = '\0';
+    mgr->groups[index].event_mask = event_mask;
+    
+    return true;
+}
+
+void notify_groups_save(NotifyGroupManager* mgr) {
+    if (!mgr) return;
+    
+    // Create or open the NotificationGroups key (overwrites existing)
+    HKEY hKeyRoot;
+    LONG result = RegCreateKeyEx(HKEY_CURRENT_USER, NOTIFY_GROUPS_REG_KEY,
+        0, NULL, REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, &hKeyRoot, NULL);
+    if (result != ERROR_SUCCESS) return;
+    
+    // Save active index
+    DWORD val = (DWORD)mgr->active_index;
+    RegSetValueEx(hKeyRoot, "active_index", 0, REG_DWORD, (LPBYTE)&val, sizeof(val));
+    
+    RegCloseKey(hKeyRoot);
+    
+    // First delete all old group subkeys up to max
+    char subkey_buf[512];
+    for (int i = 0; i < MAX_NOTIFY_GROUPS + 5; i++) {
+        snprintf(subkey_buf, sizeof(subkey_buf), "%s\\Group_%d", NOTIFY_GROUPS_REG_KEY, i);
+        RegDeleteKey(HKEY_CURRENT_USER, subkey_buf);
+    }
+    
+    // Save each group as a subkey
+    for (int i = 0; i < mgr->count; i++) {
+        snprintf(subkey_buf, sizeof(subkey_buf), "%s\\Group_%d", NOTIFY_GROUPS_REG_KEY, i);
+        
+        HKEY hKeyGroup;
+        result = RegCreateKeyEx(HKEY_CURRENT_USER, subkey_buf,
+            0, NULL, REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, &hKeyGroup, NULL);
+        if (result != ERROR_SUCCESS) continue;
+        
+        // Save name
+        RegSetValueEx(hKeyGroup, "name", 0, REG_SZ, 
+            (LPBYTE)mgr->groups[i].name, (DWORD)(strlen(mgr->groups[i].name) + 1));
+        
+        // Save event mask
+        val = (DWORD)mgr->groups[i].event_mask;
+        RegSetValueEx(hKeyGroup, "event_mask", 0, REG_DWORD, (LPBYTE)&val, sizeof(val));
+        
+        // Save is_default flag
+        val = mgr->groups[i].is_default ? 1 : 0;
+        RegSetValueEx(hKeyGroup, "is_default", 0, REG_DWORD, (LPBYTE)&val, sizeof(val));
+        
+        RegCloseKey(hKeyGroup);
+    }
+}
+
+void notify_groups_load(NotifyGroupManager* mgr) {
+    if (!mgr) return;
+    
+    HKEY hKeyRoot;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, NOTIFY_GROUPS_REG_KEY,
+        0, KEY_READ, &hKeyRoot);
+    if (result != ERROR_SUCCESS) return;
+    
+    // Read active index
+    DWORD val = 0;
+    DWORD size = sizeof(DWORD);
+    RegQueryValueEx(hKeyRoot, "active_index", NULL, NULL, (LPBYTE)&val, &size);
+    mgr->active_index = (int)val;
+    
+    RegCloseKey(hKeyRoot);
+    
+    // Enumerate group subkeys
+    mgr->count = 0;
+    for (int i = 0; i < MAX_NOTIFY_GROUPS; i++) {
+        char subkey[256];
+        snprintf(subkey, sizeof(subkey), "%s\\Group_%d", NOTIFY_GROUPS_REG_KEY, i);
+        
+        HKEY hKeyGroup;
+        result = RegOpenKeyEx(HKEY_CURRENT_USER, subkey, 0, KEY_READ, &hKeyGroup);
+        if (result != ERROR_SUCCESS) break;
+        
+        // Read name with proper error checking
+        char name[MAX_GROUP_NAME] = "";
+        DWORD name_size = sizeof(name);
+        DWORD name_type = 0;
+        result = RegQueryValueEx(hKeyGroup, "name", NULL, &name_type, (LPBYTE)name, &name_size);
+        if (result != ERROR_SUCCESS || name_type != REG_SZ || name[0] == '\0') {
+            RegCloseKey(hKeyGroup);
+            break; // Corrupt entry, stop enumeration
+        }
+        strncpy(mgr->groups[i].name, name, MAX_GROUP_NAME - 1);
+        mgr->groups[i].name[MAX_GROUP_NAME - 1] = '\0';
+        
+        // Read event mask
+        val = 0;
+        size = sizeof(DWORD);
+        DWORD mask_type = 0;
+        result = RegQueryValueEx(hKeyGroup, "event_mask", NULL, &mask_type, (LPBYTE)&val, &size);
+        if (result != ERROR_SUCCESS || mask_type != REG_DWORD) {
+            val = 0;
+        }
+        mgr->groups[i].event_mask = (unsigned int)val;
+        
+        // Read is_default
+        val = 0;
+        size = sizeof(DWORD);
+        DWORD def_type = 0;
+        result = RegQueryValueEx(hKeyGroup, "is_default", NULL, &def_type, (LPBYTE)&val, &size);
+        mgr->groups[i].is_default = (result == ERROR_SUCCESS && def_type == REG_DWORD && val != 0);
+        
+        RegCloseKey(hKeyGroup);
+        mgr->count++;
+    }
+    
+    // Validate active_index
+    if (mgr->active_index < 0 || mgr->active_index >= mgr->count) {
+        mgr->active_index = 0;
+    }
+}
+
+int notify_groups_migrate_old_settings(NotifyGroupManager* mgr, int old_notification_mode) {
+    if (!mgr) return -1;
+    
+    // Map old notification_mode to default group
+    // 0 = NOTIFY_ALL -> "All notifications" (index 0)
+    // 1 = NOTIFY_CRITICAL_ONLY -> "Critical only" (index 1)
+    // 2 = NOTIFY_NONE -> "None" (index 2)
+    
+    int target_index;
+    switch (old_notification_mode) {
+        case 0: target_index = 0; break; // ALL
+        case 1: target_index = 1; break; // CRITICAL
+        case 2: target_index = 2; break; // NONE
+        default: target_index = 0; break;
+    }
+    
+    // Ensure the target group exists
+    if (target_index < mgr->count) {
+        mgr->active_index = target_index;
+        notify_groups_save(mgr);
+        return target_index;
+    }
+    
+    return -1;
+}
+
+int notify_groups_find_default_by_mask(NotifyGroupManager* mgr, unsigned int mask) {
+    if (!mgr) return -1;
+    
+    for (int i = 0; i < mgr->count; i++) {
+        if (mgr->groups[i].is_default && mgr->groups[i].event_mask == mask) {
+            return i;
+        }
+    }
+    
+    return -1;
+}

--- a/src/notify_groups.h
+++ b/src/notify_groups.h
@@ -1,0 +1,89 @@
+// Notification groups for nosleep
+// Provides customizable notification event filtering via named groups
+#ifndef NOTIFY_GROUPS_H
+#define NOTIFY_GROUPS_H
+
+#include <windows.h>
+#include <stdbool.h>
+
+// Registry key for storing notification groups
+#define NOTIFY_GROUPS_REG_KEY "Software\\nosleep\\settings\\NotificationGroups"
+
+// Maximum number of notification groups
+#define MAX_NOTIFY_GROUPS 20
+
+// Maximum group name length
+#define MAX_GROUP_NAME 128
+
+// Maximum number of notification events
+#define MAX_NOTIFY_EVENTS 32
+
+// Notification event IDs
+// Each event represents a specific notification type that can be individually toggled
+typedef enum {
+    NOTIFY_EVENT_APP_START = 0,         // "Application started" - shown on system tray startup
+    NOTIFY_EVENT_SESSION_START = 1,     // "Session started" - shown when nosleep session begins
+    NOTIFY_EVENT_SESSION_STOP = 2,      // "Session stopped" - shown when session is manually stopped
+    NOTIFY_EVENT_TIMER_EXPIRED = 3,     // "Timer expired" - shown when duration finishes
+    NOTIFY_EVENT_ERROR = 4,             // "Error occurred" - shown on errors (thread failures, API errors)
+    NOTIFY_EVENT_COUNTDOWN_CANCEL = 5,  // "Countdown cancelled" - shown when sleep/shutdown cancelled
+    NOTIFY_EVENT_UPDATE_AVAILABLE = 6,  // "Update available" - shown when new version found
+    NOTIFY_EVENT_UPDATE_CHECK_FAILED = 7, // "Update check failed" - shown when network fails
+    NOTIFY_EVENT_SLEEP_DETECTED = 8,    // "Sleep detected" - shown when system goes to sleep
+    NOTIFY_EVENT_ACTION_FAILED = 9,     // "Action failed" - shown when sleep/shutdown fails
+    NOTIFY_EVENT_COUNT = 10             // Total number of defined events
+} NotifyEventId;
+
+// Human-readable names for each event
+extern const char* NOTIFY_EVENT_NAMES[NOTIFY_EVENT_COUNT];
+
+// Notification group structure
+typedef struct {
+    char name[MAX_GROUP_NAME];      // User-visible group name
+    unsigned int event_mask;        // Bitmask: bit N = 1 means event N is enabled
+    bool is_default;                // True for built-in default groups (cannot be deleted)
+} NotifyGroup;
+
+// Notification group collection
+typedef struct {
+    NotifyGroup groups[MAX_NOTIFY_GROUPS];
+    int count;                      // Number of groups
+    int active_index;               // Index of the currently active group
+} NotifyGroupManager;
+
+// Initialize the notification group manager
+// Reads groups from registry, migrates old settings if needed
+void notify_groups_init(NotifyGroupManager* mgr);
+
+// Get the currently active group
+NotifyGroup* notify_groups_get_active(NotifyGroupManager* mgr);
+
+// Set the active group by index
+bool notify_groups_set_active(NotifyGroupManager* mgr, int index);
+
+// Check if a notification event should be shown based on the active group
+bool notify_groups_should_show(NotifyGroupManager* mgr, NotifyEventId event_id);
+
+// Add a new custom group
+int notify_groups_add(NotifyGroupManager* mgr, const char* name, unsigned int event_mask);
+
+// Remove a custom group (cannot remove default groups)
+bool notify_groups_remove(NotifyGroupManager* mgr, int index);
+
+// Update a group's name and event mask
+bool notify_groups_update(NotifyGroupManager* mgr, int index, const char* name, unsigned int event_mask);
+
+// Save all groups to registry
+void notify_groups_save(NotifyGroupManager* mgr);
+
+// Load groups from registry
+void notify_groups_load(NotifyGroupManager* mgr);
+
+// Migrate old single notification_mode to group system
+// Returns the index of the migrated group (-1 if no migration needed)
+int notify_groups_migrate_old_settings(NotifyGroupManager* mgr, int old_notification_mode);
+
+// Get the index of a default group by its event mask pattern
+int notify_groups_find_default_by_mask(NotifyGroupManager* mgr, unsigned int mask);
+
+#endif // NOTIFY_GROUPS_H

--- a/src/tray.c
+++ b/src/tray.c
@@ -3,12 +3,15 @@
 #include "core.h"
 #include "constants.h"
 #include "resources.h"
+#include "notify_groups.h"
+#include "updater.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <powrprof.h>
 #include <winhttp.h>
+#include <commctrl.h>
 #include <ctype.h>
 
 // Window class name for tray icon
@@ -67,6 +70,9 @@ static bool remove_app_from_path(void);
 static int str_icmp_n(const char* a, const char* b, size_t n);
 static char* get_exe_dir(void);
 LRESULT CALLBACK tray_window_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+// Forward declaration for notification group edit dialog
+void show_notify_group_edit_dialog(HWND hwnd_parent, NotifyGroupManager* mgr, int group_index);
 
 // Font helper: creates a high-quality ClearType font for dialog controls
 static HFONT create_dialog_font(int font_size) {
@@ -276,6 +282,34 @@ bool tray_init(NoSleepTray* tray) {
     // If add_to_path is enabled, ensure it's applied on startup
     if (tray->add_to_path) {
         add_app_to_path();
+    }
+
+    // Initialize notification groups and migrate old settings
+    notify_groups_init(&tray->notify_groups);
+    // The old notification_mode is used for migration if no groups exist
+    // Migration happens inside notify_groups_init if registry is empty
+    // We still check to see if migration is needed
+    {
+        // Check if old notification_mode key exists and no groups yet
+        HKEY hKey;
+        LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, 
+            "Software\\nosleep\\settings", 0, KEY_READ, &hKey);
+        if (result == ERROR_SUCCESS) {
+            DWORD old_mode;
+            DWORD size = sizeof(DWORD);
+            result = RegQueryValueEx(hKey, "notification_mode", NULL, NULL, 
+                                     (LPBYTE)&old_mode, &size);
+            RegCloseKey(hKey);
+            
+            if (result == ERROR_SUCCESS && tray->notify_groups.count == 0) {
+                // No groups loaded from registry - this is a fresh start
+                // Use the old notification_mode to set active group
+                tray->notification_mode = (int)old_mode;
+            }
+        }
+        // Migrate: if groups were just loaded from registry with defaults,
+        // use the old notification_mode value to select active group
+        notify_groups_migrate_old_settings(&tray->notify_groups, tray->notification_mode);
     }
 
     // Check for updates on startup if enabled
@@ -2702,6 +2736,9 @@ void tray_save_settings(NoSleepTray* tray) {
     RegSetValueEx(hKey, "session_finished_action", 0, REG_DWORD, (LPBYTE)&val, sizeof(val));
 
     RegCloseKey(hKey);
+
+    // Save notification groups separately
+    notify_groups_save(&tray->notify_groups);
 }
 
 bool tray_save_settings_cli(int session_finished_action,
@@ -2846,7 +2883,7 @@ void tray_set_add_to_path(NoSleepTray* tray, bool enable) {
 void tray_show_notification(NoSleepTray* tray, const char* title, const char* message, bool critical) {
     if (!tray || !tray->hwnd) return;
     
-    // Check notification mode
+    // Check notification mode (legacy check)
     if (tray->notification_mode == NOTIFY_NONE) return;
     if (tray->notification_mode == NOTIFY_CRITICAL_ONLY && !critical) return;
     
@@ -2870,6 +2907,20 @@ void tray_show_notification(NoSleepTray* tray, const char* title, const char* me
     
     // Reset flags
     tray->nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+}
+
+// Event-aware notification: checks notification group filtering before showing
+void tray_show_notification_event(NoSleepTray* tray, int event_type, const char* title, const char* message, bool critical) {
+    if (!tray) return;
+    
+    // Check if this event type is enabled in the current notification group
+    if (!notify_groups_should_show(&tray->notify_groups, (NotifyEventId)event_type)) {
+        return;
+    }
+    
+    // Also respect the legacy notification_mode as a fallback
+    // (the group system is the primary filter now)
+    tray_show_notification(tray, title, message, critical);
 }
 
 // Simple input dialog window procedure
@@ -3053,13 +3104,42 @@ static int tray_show_custom_dialog(NoSleepTray* tray) {
 #define IDC_AUTO_CHECK_INTERVAL  2006
 #define IDC_SETTINGS_OK          2007
 #define IDC_SETTINGS_CANCEL      2008
-#define IDC_NOTIFY_ALL           2009
-#define IDC_NOTIFY_CRITICAL      2010
-#define IDC_NOTIFY_NONE          2011
 #define IDC_ADD_TO_PATH          2012
+#define IDC_SETTINGS_TAB         2013
+#define IDC_NOTIFY_GROUP_LIST    2014
+
+// Notification group edit popup control IDs
+#define IDC_NOTIFY_GROUP_NAME       2100
+#define IDC_NOTIFY_EVENT_CHECK_START 2101
+#define IDC_NOTIFY_GROUP_EDIT_OK    2200
+#define IDC_NOTIFY_GROUP_EDIT_CANCEL 2201
+#define IDC_NOTIFY_ADD_GROUP        2202
+#define IDC_NOTIFY_DEL_GROUP        2203
+#define IDC_NOTIFY_CONFIGURE_GROUP  2204
+#define IDC_NOTIFY_SET_ACTIVE       2205
+
+// Tab indices
+#define TAB_GENERAL       0
+#define TAB_NOTIFICATIONS 1
+
+// Forward declarations
+static LRESULT CALLBACK notify_group_edit_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static void create_general_tab(HWND hwnd_tab, NoSleepTray* tray);
+static void create_notifications_tab(HWND hwnd_tab, NoSleepTray* tray);
+static void refresh_notification_group_list(HWND hwnd_tab, NoSleepTray* tray);
+
+// Global for passing group edit info
+static struct {
+    NotifyGroupManager* mgr;
+    int group_index;
+    HWND hwnd_parent;
+} g_notify_edit_ctx = {NULL, -1, NULL};
 
 static LRESULT CALLBACK settings_dialog_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     static NoSleepTray* settings_tray = NULL;
+    static HWND hTab = NULL;
+    static HWND hGeneralTab = NULL;
+    static HWND hNotifyTab = NULL;
     static HWND hIntervalCombo = NULL;
 
     switch (msg) {
@@ -3070,121 +3150,70 @@ static LRESULT CALLBACK settings_dialog_proc(HWND hwnd, UINT msg, WPARAM wParam,
             if (!settings_tray) return -1;
 
             HINSTANCE hInst = GetModuleHandle(NULL);
-            int y = 20;
 
-            CreateWindowEx(0, "BUTTON", "Prevent display sleep",
-                WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
-                20, y, 220, 25, hwnd, (HMENU)IDC_PREVENT_DISPLAY, hInst, NULL);
-            if (settings_tray->prevent_display) {
-                SendDlgItemMessage(hwnd, IDC_PREVENT_DISPLAY, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 30;
+            // Register common controls for tab control
+            INITCOMMONCONTROLSEX icex;
+            icex.dwSize = sizeof(INITCOMMONCONTROLSEX);
+            icex.dwICC = ICC_TAB_CLASSES;
+            InitCommonControlsEx(&icex);
 
-            CreateWindowEx(0, "BUTTON", "Enable away mode",
-                WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
-                20, y, 220, 25, hwnd, (HMENU)IDC_AWAY_MODE, hInst, NULL);
-            if (settings_tray->away_mode) {
-                SendDlgItemMessage(hwnd, IDC_AWAY_MODE, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 30;
+            // Create tab control
+            hTab = CreateWindowEx(0, WC_TABCONTROL, NULL,
+                WS_CHILD | WS_VISIBLE | TCS_FIXEDWIDTH,
+                10, 10, 460, 350,
+                hwnd, (HMENU)IDC_SETTINGS_TAB, hInst, NULL);
 
-            CreateWindowEx(0, "BUTTON", "Auto-start with Windows",
-                WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
-                20, y, 220, 25, hwnd, (HMENU)IDC_AUTO_START, hInst, NULL);
-            if (settings_tray->start_on_startup) {
-                SendDlgItemMessage(hwnd, IDC_AUTO_START, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 30;
+            // Add tabs
+            TCITEM tie = {0};
+            tie.mask = TCIF_TEXT;
+            
+            char tab1_text[] = "General";
+            tie.pszText = tab1_text;
+            TabCtrl_InsertItem(hTab, TAB_GENERAL, &tie);
+            
+            char tab2_text[] = "Notifications";
+            tie.pszText = tab2_text;
+            TabCtrl_InsertItem(hTab, TAB_NOTIFICATIONS, &tie);
 
-            CreateWindowEx(0, "BUTTON", "Enable verbose logging",
-                WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
-                20, y, 220, 25, hwnd, (HMENU)IDC_VERBOSE_LOGGING, hInst, NULL);
-            if (settings_tray->verbose) {
-                SendDlgItemMessage(hwnd, IDC_VERBOSE_LOGGING, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 30;
-
-            CreateWindowEx(0, "BUTTON", "Check for updates on startup",
-                WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
-                20, y, 220, 25, hwnd, (HMENU)IDC_CHECK_UPDATES_STARTUP, hInst, NULL);
-            if (settings_tray->check_updates_on_startup) {
-                SendDlgItemMessage(hwnd, IDC_CHECK_UPDATES_STARTUP, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 30;
-
-            CreateWindowEx(0, "STATIC", "Auto check updates interval:",
+            // Create tab page windows (initially hidden, shown when tab selected)
+            // General tab
+            hGeneralTab = CreateWindowEx(0, "STATIC", NULL,
                 WS_CHILD | WS_VISIBLE,
-                20, y, 180, 20, hwnd, NULL, hInst, NULL);
-            y += 22;
+                15, 35, 450, 320,
+                hwnd, NULL, hInst, NULL);
+            create_general_tab(hGeneralTab, settings_tray);
+            
+            // Notifications tab (initially hidden)
+            hNotifyTab = CreateWindowEx(0, "STATIC", NULL,
+                WS_CHILD,  // Not visible initially
+                15, 35, 450, 320,
+                hwnd, NULL, hInst, NULL);
+            create_notifications_tab(hNotifyTab, settings_tray);
 
-            hIntervalCombo = CreateWindowEx(WS_EX_CLIENTEDGE, "COMBOBOX", NULL,
-                WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | WS_TABSTOP,
-                20, y, 180, 80, hwnd, (HMENU)IDC_AUTO_CHECK_INTERVAL, hInst, NULL);
-            if (hIntervalCombo) {
-                SendMessage(hIntervalCombo, CB_ADDSTRING, 0, (LPARAM)"Never");
-                SendMessage(hIntervalCombo, CB_ADDSTRING, 0, (LPARAM)"Daily");
-                SendMessage(hIntervalCombo, CB_ADDSTRING, 0, (LPARAM)"Weekly");
-                int idx = settings_tray->auto_check_interval;
-                if (idx < 0) idx = 0;
-                if (idx > 2) idx = 2;
-                SendMessage(hIntervalCombo, CB_SETCURSEL, (WPARAM)idx, 0);
-            }
-            y += 30;
+            // Show the first tab by default
+            ShowWindow(hGeneralTab, SW_SHOW);
+            ShowWindow(hNotifyTab, SW_HIDE);
 
-            // Notification mode: group label
-            CreateWindowEx(0, "STATIC", "Notifications:",
-                WS_CHILD | WS_VISIBLE,
-                20, y, 220, 20, hwnd, NULL, hInst, NULL);
-            y += 20;
+            // Find the interval combo (created inside the general tab's static parent)
+            hIntervalCombo = GetDlgItem(hGeneralTab, IDC_AUTO_CHECK_INTERVAL);
 
-            CreateWindowEx(0, "BUTTON", "Show all notifications",
-                WS_CHILD | WS_VISIBLE | BS_AUTORADIOBUTTON | WS_TABSTOP | WS_GROUP,
-                30, y, 220, 22, hwnd, (HMENU)IDC_NOTIFY_ALL, hInst, NULL);
-            if (settings_tray->notification_mode == NOTIFY_ALL) {
-                SendDlgItemMessage(hwnd, IDC_NOTIFY_ALL, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 24;
-
-            CreateWindowEx(0, "BUTTON", "Show only critical notifications",
-                WS_CHILD | WS_VISIBLE | BS_AUTORADIOBUTTON | WS_TABSTOP,
-                30, y, 220, 22, hwnd, (HMENU)IDC_NOTIFY_CRITICAL, hInst, NULL);
-            if (settings_tray->notification_mode == NOTIFY_CRITICAL_ONLY) {
-                SendDlgItemMessage(hwnd, IDC_NOTIFY_CRITICAL, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 24;
-
-            CreateWindowEx(0, "BUTTON", "Suppress all notifications",
-                WS_CHILD | WS_VISIBLE | BS_AUTORADIOBUTTON | WS_TABSTOP,
-                30, y, 220, 22, hwnd, (HMENU)IDC_NOTIFY_NONE, hInst, NULL);
-            if (settings_tray->notification_mode == NOTIFY_NONE) {
-                SendDlgItemMessage(hwnd, IDC_NOTIFY_NONE, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 30;
-
-            CreateWindowEx(0, "BUTTON", "Add nosleep to environment PATH",
-                WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
-                20, y, 240, 25, hwnd, (HMENU)IDC_ADD_TO_PATH, hInst, NULL);
-            if (settings_tray->add_to_path) {
-                SendDlgItemMessage(hwnd, IDC_ADD_TO_PATH, BM_SETCHECK, BST_CHECKED, 0);
-            }
-            y += 30;
-
+            // OK and Cancel buttons at the bottom (outside tab control)
             CreateWindowEx(0, "BUTTON", "OK",
                 WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON,
-                40, y, 80, 30, hwnd, (HMENU)IDC_SETTINGS_OK, hInst, NULL);
+                150, 370, 80, 28, hwnd, (HMENU)IDC_SETTINGS_OK, hInst, NULL);
 
             CreateWindowEx(0, "BUTTON", "Cancel",
                 WS_CHILD | WS_VISIBLE | WS_TABSTOP,
-                140, y, 80, 30, hwnd, (HMENU)IDC_SETTINGS_CANCEL, hInst, NULL);
+                250, 370, 80, 28, hwnd, (HMENU)IDC_SETTINGS_CANCEL, hInst, NULL);
 
-            // Apply high-quality ClearType font to all dialog controls
+            // Apply font
             HFONT settingsFont = create_dialog_font(14);
             if (settingsFont) {
                 EnumChildWindows(hwnd, set_child_font_proc, (LPARAM)settingsFont);
-                // Store font handle on window for cleanup in WM_DESTROY
                 SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)settingsFont);
             }
 
+            // Center on screen
             RECT rc;
             GetWindowRect(hwnd, &rc);
             int screenWidth = GetSystemMetrics(SM_CXSCREEN);
@@ -3196,35 +3225,42 @@ static LRESULT CALLBACK settings_dialog_proc(HWND hwnd, UINT msg, WPARAM wParam,
             return 0;
         }
 
+        case WM_NOTIFY:
+        {
+            if (((LPNMHDR)lParam)->idFrom == IDC_SETTINGS_TAB &&
+                ((LPNMHDR)lParam)->code == TCN_SELCHANGE) {
+                int sel = TabCtrl_GetCurSel(hTab);
+                ShowWindow(hGeneralTab, sel == TAB_GENERAL ? SW_SHOW : SW_HIDE);
+                ShowWindow(hNotifyTab, sel == TAB_NOTIFICATIONS ? SW_SHOW : SW_HIDE);
+                if (sel == TAB_NOTIFICATIONS) {
+                    refresh_notification_group_list(hNotifyTab, settings_tray);
+                }
+            }
+            break;
+        }
+
         case WM_COMMAND:
             switch (LOWORD(wParam)) {
                 case IDC_SETTINGS_OK:
                 {
                     if (!settings_tray) break;
-                    settings_tray->prevent_display = (SendDlgItemMessage(hwnd, IDC_PREVENT_DISPLAY, BM_GETCHECK, 0, 0) == BST_CHECKED);
-                    settings_tray->away_mode = (SendDlgItemMessage(hwnd, IDC_AWAY_MODE, BM_GETCHECK, 0, 0) == BST_CHECKED);
-                    bool auto_start = (SendDlgItemMessage(hwnd, IDC_AUTO_START, BM_GETCHECK, 0, 0) == BST_CHECKED);
+                    
+                    // Read general tab settings (controls are children of hGeneralTab)
+                    settings_tray->prevent_display = (SendDlgItemMessage(hGeneralTab, IDC_PREVENT_DISPLAY, BM_GETCHECK, 0, 0) == BST_CHECKED);
+                    settings_tray->away_mode = (SendDlgItemMessage(hGeneralTab, IDC_AWAY_MODE, BM_GETCHECK, 0, 0) == BST_CHECKED);
+                    bool auto_start = (SendDlgItemMessage(hGeneralTab, IDC_AUTO_START, BM_GETCHECK, 0, 0) == BST_CHECKED);
                     if (auto_start != settings_tray->start_on_startup) {
                         tray_set_startup_enabled(settings_tray, auto_start);
                     }
-                    settings_tray->verbose = (SendDlgItemMessage(hwnd, IDC_VERBOSE_LOGGING, BM_GETCHECK, 0, 0) == BST_CHECKED);
-                    settings_tray->check_updates_on_startup = (SendDlgItemMessage(hwnd, IDC_CHECK_UPDATES_STARTUP, BM_GETCHECK, 0, 0) == BST_CHECKED);
+                    settings_tray->verbose = (SendDlgItemMessage(hGeneralTab, IDC_VERBOSE_LOGGING, BM_GETCHECK, 0, 0) == BST_CHECKED);
+                    settings_tray->check_updates_on_startup = (SendDlgItemMessage(hGeneralTab, IDC_CHECK_UPDATES_STARTUP, BM_GETCHECK, 0, 0) == BST_CHECKED);
                     if (hIntervalCombo) {
                         int sel = (int)SendMessage(hIntervalCombo, CB_GETCURSEL, 0, 0);
                         if (sel != CB_ERR) {
                             settings_tray->auto_check_interval = sel;
                         }
                     }
-                    // Read notification mode from radio buttons
-                    if (SendDlgItemMessage(hwnd, IDC_NOTIFY_ALL, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        settings_tray->notification_mode = NOTIFY_ALL;
-                    } else if (SendDlgItemMessage(hwnd, IDC_NOTIFY_CRITICAL, BM_GETCHECK, 0, 0) == BST_CHECKED) {
-                        settings_tray->notification_mode = NOTIFY_CRITICAL_ONLY;
-                    } else {
-                        settings_tray->notification_mode = NOTIFY_NONE;
-                    }
-                    // Handle add to PATH setting
-                    bool new_add_to_path = (SendDlgItemMessage(hwnd, IDC_ADD_TO_PATH, BM_GETCHECK, 0, 0) == BST_CHECKED);
+                    bool new_add_to_path = (SendDlgItemMessage(hGeneralTab, IDC_ADD_TO_PATH, BM_GETCHECK, 0, 0) == BST_CHECKED);
                     if (new_add_to_path != settings_tray->add_to_path) {
                         settings_tray->add_to_path = new_add_to_path;
                         if (new_add_to_path) {
@@ -3233,25 +3269,99 @@ static LRESULT CALLBACK settings_dialog_proc(HWND hwnd, UINT msg, WPARAM wParam,
                             remove_app_from_path();
                         }
                     }
+
+                    // Save notification groups
+                    notify_groups_save(&settings_tray->notify_groups);
+
                     tray_save_settings(settings_tray);
                     DestroyWindow(hwnd);
                     break;
                 }
+
                 case IDC_SETTINGS_CANCEL:
                     DestroyWindow(hwnd);
                     break;
+
+                case IDC_NOTIFY_ADD_GROUP:
+                {
+                    show_notify_group_edit_dialog(hwnd, &settings_tray->notify_groups, -1);
+                    refresh_notification_group_list(hNotifyTab, settings_tray);
+                    break;
+                }
+
+                case IDC_NOTIFY_CONFIGURE_GROUP:
+                {
+                    HWND hList = GetDlgItem(hNotifyTab, IDC_NOTIFY_GROUP_LIST);
+                    if (!hList) break;
+                    int sel = (int)SendMessage(hList, LB_GETCURSEL, 0, 0);
+                    if (sel == LB_ERR) break;
+                    
+                    int group_idx = (int)SendMessage(hList, LB_GETITEMDATA, (WPARAM)sel, 0);
+                    if (group_idx < 0 || group_idx >= settings_tray->notify_groups.count) break;
+                    
+                    show_notify_group_edit_dialog(hwnd, &settings_tray->notify_groups, group_idx);
+                    refresh_notification_group_list(hNotifyTab, settings_tray);
+                    break;
+                }
+
+                case IDC_NOTIFY_SET_ACTIVE:
+                {
+                    HWND hList = GetDlgItem(hNotifyTab, IDC_NOTIFY_GROUP_LIST);
+                    if (!hList) break;
+                    int sel = (int)SendMessage(hList, LB_GETCURSEL, 0, 0);
+                    if (sel == LB_ERR) break;
+                    
+                    int group_idx = (int)SendMessage(hList, LB_GETITEMDATA, (WPARAM)sel, 0);
+                    if (group_idx < 0 || group_idx >= settings_tray->notify_groups.count) break;
+                    
+                    if (notify_groups_set_active(&settings_tray->notify_groups, group_idx)) {
+                        notify_groups_save(&settings_tray->notify_groups);
+                        refresh_notification_group_list(hNotifyTab, settings_tray);
+                    }
+                    break;
+                }
+
+                case IDC_NOTIFY_DEL_GROUP:
+                {
+                    HWND hList = GetDlgItem(hNotifyTab, IDC_NOTIFY_GROUP_LIST);
+                    if (!hList) break;
+                    int sel = (int)SendMessage(hList, LB_GETCURSEL, 0, 0);
+                    if (sel == LB_ERR) break;
+                    
+                    int group_idx = (int)SendMessage(hList, LB_GETITEMDATA, (WPARAM)sel, 0);
+                    if (group_idx < 0 || group_idx >= settings_tray->notify_groups.count) break;
+                    
+                    // Cannot delete default groups
+                    if (settings_tray->notify_groups.groups[group_idx].is_default) {
+                        MessageBox(hwnd, "Default notification groups cannot be deleted.",
+                            "Cannot Delete", MB_OK | MB_ICONINFORMATION | MB_TOPMOST);
+                        break;
+                    }
+                    
+                    char msg[256];
+                    snprintf(msg, sizeof(msg), "Delete notification group \"%s\"?",
+                             settings_tray->notify_groups.groups[group_idx].name);
+                    int confirm = MessageBox(hwnd, msg, "Confirm Delete",
+                        MB_YESNO | MB_ICONQUESTION | MB_TOPMOST);
+                    if (confirm == IDYES) {
+                        notify_groups_remove(&settings_tray->notify_groups, group_idx);
+                        notify_groups_save(&settings_tray->notify_groups);
+                        refresh_notification_group_list(hNotifyTab, settings_tray);
+                    }
+                    break;
+                }
             }
             break;
 
         case WM_DESTROY:
             {
-                // Clean up GDI font stored via SetWindowLongPtr
                 HFONT hFont = (HFONT)GetWindowLongPtr(hwnd, GWLP_USERDATA);
-                if (hFont) {
-                    DeleteObject(hFont);
-                }
+                if (hFont) DeleteObject(hFont);
             }
             settings_tray = NULL;
+            hTab = NULL;
+            hGeneralTab = NULL;
+            hNotifyTab = NULL;
             hIntervalCombo = NULL;
             PostQuitMessage(0);
             break;
@@ -3262,6 +3372,145 @@ static LRESULT CALLBACK settings_dialog_proc(HWND hwnd, UINT msg, WPARAM wParam,
     }
 
     return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+// Create controls for the "General" tab
+static void create_general_tab(HWND hwnd_parent, NoSleepTray* tray) {
+    HINSTANCE hInst = GetModuleHandle(NULL);
+    int y = 10;
+
+    CreateWindowEx(0, "BUTTON", "Prevent display sleep",
+        WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+        20, y, 240, 25, hwnd_parent, (HMENU)IDC_PREVENT_DISPLAY, hInst, NULL);
+    if (tray->prevent_display) {
+        SendDlgItemMessage(hwnd_parent, IDC_PREVENT_DISPLAY, BM_SETCHECK, BST_CHECKED, 0);
+    }
+    y += 30;
+
+    CreateWindowEx(0, "BUTTON", "Enable away mode",
+        WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+        20, y, 240, 25, hwnd_parent, (HMENU)IDC_AWAY_MODE, hInst, NULL);
+    if (tray->away_mode) {
+        SendDlgItemMessage(hwnd_parent, IDC_AWAY_MODE, BM_SETCHECK, BST_CHECKED, 0);
+    }
+    y += 30;
+
+    CreateWindowEx(0, "BUTTON", "Auto-start with Windows",
+        WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+        20, y, 240, 25, hwnd_parent, (HMENU)IDC_AUTO_START, hInst, NULL);
+    if (tray->start_on_startup) {
+        SendDlgItemMessage(hwnd_parent, IDC_AUTO_START, BM_SETCHECK, BST_CHECKED, 0);
+    }
+    y += 30;
+
+    CreateWindowEx(0, "BUTTON", "Enable verbose logging",
+        WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+        20, y, 240, 25, hwnd_parent, (HMENU)IDC_VERBOSE_LOGGING, hInst, NULL);
+    if (tray->verbose) {
+        SendDlgItemMessage(hwnd_parent, IDC_VERBOSE_LOGGING, BM_SETCHECK, BST_CHECKED, 0);
+    }
+    y += 30;
+
+    CreateWindowEx(0, "BUTTON", "Check for updates on startup",
+        WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+        20, y, 240, 25, hwnd_parent, (HMENU)IDC_CHECK_UPDATES_STARTUP, hInst, NULL);
+    if (tray->check_updates_on_startup) {
+        SendDlgItemMessage(hwnd_parent, IDC_CHECK_UPDATES_STARTUP, BM_SETCHECK, BST_CHECKED, 0);
+    }
+    y += 30;
+
+    CreateWindowEx(0, "STATIC", "Auto check updates interval:",
+        WS_CHILD | WS_VISIBLE,
+        20, y, 180, 20, hwnd_parent, NULL, hInst, NULL);
+    y += 22;
+
+    HWND hCombo = CreateWindowEx(WS_EX_CLIENTEDGE, "COMBOBOX", NULL,
+        WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | WS_TABSTOP,
+        20, y, 200, 80, hwnd_parent, (HMENU)IDC_AUTO_CHECK_INTERVAL, hInst, NULL);
+    if (hCombo) {
+        SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM)"Never");
+        SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM)"Daily");
+        SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM)"Weekly");
+        int idx = tray->auto_check_interval;
+        if (idx < 0) idx = 0;
+        if (idx > 2) idx = 2;
+        SendMessage(hCombo, CB_SETCURSEL, (WPARAM)idx, 0);
+    }
+    y += 30;
+
+    CreateWindowEx(0, "BUTTON", "Add nosleep to environment PATH",
+        WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+        20, y, 260, 25, hwnd_parent, (HMENU)IDC_ADD_TO_PATH, hInst, NULL);
+    if (tray->add_to_path) {
+        SendDlgItemMessage(hwnd_parent, IDC_ADD_TO_PATH, BM_SETCHECK, BST_CHECKED, 0);
+    }
+}
+
+// Create controls for the "Notifications" tab
+static void create_notifications_tab(HWND hwnd_parent, NoSleepTray* tray) {
+    HINSTANCE hInst = GetModuleHandle(NULL);
+    (void)tray;
+
+    // Create group listbox
+    CreateWindowEx(WS_EX_CLIENTEDGE, "LISTBOX", NULL,
+        WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_HASSTRINGS,
+        15, 10, 280, 200,
+        hwnd_parent, (HMENU)IDC_NOTIFY_GROUP_LIST, hInst, NULL);
+
+    // Configure button
+    CreateWindowEx(0, "BUTTON", "Configure...",
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+        305, 10, 120, 28, hwnd_parent, (HMENU)IDC_NOTIFY_CONFIGURE_GROUP, hInst, NULL);
+
+    // Delete button
+    CreateWindowEx(0, "BUTTON", "Delete",
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+        305, 45, 120, 28, hwnd_parent, (HMENU)IDC_NOTIFY_DEL_GROUP, hInst, NULL);
+
+    // Set Active button
+    CreateWindowEx(0, "BUTTON", "Set Active",
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+        305, 80, 120, 28, hwnd_parent, (HMENU)IDC_NOTIFY_SET_ACTIVE, hInst, NULL);
+
+    // Add button
+    CreateWindowEx(0, "BUTTON", "Add Group...",
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+        305, 115, 120, 28, hwnd_parent, (HMENU)IDC_NOTIFY_ADD_GROUP, hInst, NULL);
+
+    // Help text for notification groups
+    CreateWindowEx(0, "STATIC", 
+        "Notification groups let you control which\n"
+        "notification types produce balloon messages.\n"
+        "Select a group from the list and click\n"
+        "\"Configure...\" to customize which events\n"
+        "produce notifications for that group.",
+        WS_CHILD | WS_VISIBLE,
+        15, 220, 410, 80, hwnd_parent, NULL, hInst, NULL);
+
+    refresh_notification_group_list(hwnd_parent, tray);
+}
+
+// Refresh the notification group listbox
+static void refresh_notification_group_list(HWND hwnd_parent, NoSleepTray* tray) {
+    HWND hList = GetDlgItem(hwnd_parent, IDC_NOTIFY_GROUP_LIST);
+    if (!hList || !tray) return;
+
+    SendMessage(hList, LB_RESETCONTENT, 0, 0);
+
+    for (int i = 0; i < tray->notify_groups.count; i++) {
+        NotifyGroup* g = &tray->notify_groups.groups[i];
+        char display[256];
+        const char* marker = (i == tray->notify_groups.active_index) ? " [ACTIVE]" : "";
+        snprintf(display, sizeof(display), "%s%s%s", 
+                 g->name, marker, g->is_default ? " (default)" : "");
+        int idx = (int)SendMessage(hList, LB_ADDSTRING, 0, (LPARAM)display);
+        SendMessage(hList, LB_SETITEMDATA, (WPARAM)idx, (LPARAM)i);
+    }
+
+    // Select first item by default
+    if (tray->notify_groups.count > 0) {
+        SendMessage(hList, LB_SETCURSEL, 0, 0);
+    }
 }
 
 void tray_show_settings_dialog(NoSleepTray* tray) {
@@ -3281,7 +3530,7 @@ void tray_show_settings_dialog(NoSleepTray* tray) {
     HWND hwndDlg = CreateWindowEx(
         0, "NoSleepSettingsDialog", "nosleep Settings",
         WS_POPUP | WS_CAPTION | WS_SYSMENU | DS_MODALFRAME,
-        CW_USEDEFAULT, CW_USEDEFAULT, 290, 440,
+        CW_USEDEFAULT, CW_USEDEFAULT, 490, 440,
         tray->hwnd, NULL, hInstance, (LPVOID)tray
     );
 
@@ -3298,6 +3547,232 @@ void tray_show_settings_dialog(NoSleepTray* tray) {
     }
 
     UnregisterClass("NoSleepSettingsDialog", hInstance);
+}
+
+// === Notification Group Edit Dialog ===
+// Opens a popup to edit a notification group's name and event checkboxes
+
+static LRESULT CALLBACK notify_group_edit_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    static NotifyGroupManager* edit_mgr = NULL;
+    static int edit_index = -1;
+    static HWND hCheckboxes[NOTIFY_EVENT_COUNT];
+    static HWND hNameEdit = NULL;
+
+    switch (msg) {
+        case WM_CREATE:
+        {
+            // Use the global context which was set before CreateWindowEx
+            edit_mgr = g_notify_edit_ctx.mgr;
+            edit_index = g_notify_edit_ctx.group_index;
+            
+            HINSTANCE hInst = GetModuleHandle(NULL);
+
+            int y = 15;
+
+            // Group name label
+            CreateWindowEx(0, "STATIC", "Group Name:",
+                WS_CHILD | WS_VISIBLE,
+                15, y, 100, 20, hwnd, NULL, hInst, NULL);
+
+            // Group name edit
+            hNameEdit = CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
+                WS_CHILD | WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL,
+                15, y + 22, 300, 25, hwnd, (HMENU)IDC_NOTIFY_GROUP_NAME, hInst, NULL);
+            SendMessage(hNameEdit, EM_SETLIMITTEXT, (WPARAM)(MAX_GROUP_NAME - 1), 0);
+            
+            // Set name if editing existing group
+            if (edit_index >= 0 && edit_mgr && edit_index < edit_mgr->count) {
+                SetWindowText(hNameEdit, edit_mgr->groups[edit_index].name);
+            } else {
+                SetWindowText(hNameEdit, "My Group");
+            }
+            
+            y += 55;
+
+            // Notification events checkboxes
+            CreateWindowEx(0, "STATIC", "Show notifications for these events:",
+                WS_CHILD | WS_VISIBLE,
+                15, y, 300, 20, hwnd, NULL, hInst, NULL);
+            y += 22;
+
+            unsigned int mask = 0;
+            if (edit_index >= 0 && edit_mgr && edit_index < edit_mgr->count) {
+                mask = edit_mgr->groups[edit_index].event_mask;
+            } else {
+                mask = 0xFFFFFFFF; // Default: all enabled for new groups
+            }
+
+            // Create checkboxes for each event
+            for (int i = 0; i < NOTIFY_EVENT_COUNT; i++) {
+                int row = i / 2;
+                int col = i % 2;
+                int cx = 15 + col * 220;
+                int cy = y + row * 24;
+
+                hCheckboxes[i] = CreateWindowEx(0, "BUTTON", NOTIFY_EVENT_NAMES[i],
+                    WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+                    cx, cy, 210, 22, hwnd, (HMENU)(IDC_NOTIFY_EVENT_CHECK_START + i), hInst, NULL);
+                
+                if (mask & (1 << i)) {
+                    SendMessage(hCheckboxes[i], BM_SETCHECK, BST_CHECKED, 0);
+                }
+            }
+
+            // Calculate dialog size based on number of events
+            int num_rows = (NOTIFY_EVENT_COUNT + 1) / 2;
+            int dlg_height = y + num_rows * 24 + 60;
+
+            // OK and Cancel buttons
+            CreateWindowEx(0, "BUTTON", "OK",
+                WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON,
+                70, dlg_height - 40, 80, 28, hwnd, (HMENU)IDC_NOTIFY_GROUP_EDIT_OK, hInst, NULL);
+
+            CreateWindowEx(0, "BUTTON", "Cancel",
+                WS_CHILD | WS_VISIBLE | WS_TABSTOP,
+                190, dlg_height - 40, 80, 28, hwnd, (HMENU)IDC_NOTIFY_GROUP_EDIT_CANCEL, hInst, NULL);
+
+            // Resize window to fit content
+            RECT rc;
+            GetWindowRect(hwnd, &rc);
+            int new_width = 460;
+            SetWindowPos(hwnd, NULL, 0, 0, new_width, dlg_height, SWP_NOMOVE | SWP_NOZORDER);
+
+            // Apply font
+            HFONT editFont = create_dialog_font(14);
+            if (editFont) {
+                EnumChildWindows(hwnd, set_child_font_proc, (LPARAM)editFont);
+                SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)editFont);
+            }
+
+            // Center on screen
+            GetWindowRect(hwnd, &rc);
+            int sw = GetSystemMetrics(SM_CXSCREEN);
+            int sh = GetSystemMetrics(SM_CYSCREEN);
+            SetWindowPos(hwnd, NULL, 
+                (sw - (rc.right - rc.left)) / 2,
+                (sh - (rc.bottom - rc.top)) / 2,
+                0, 0, SWP_NOSIZE | SWP_NOZORDER);
+
+            return 0;
+        }
+
+        case WM_COMMAND:
+            switch (LOWORD(wParam)) {
+                case IDC_NOTIFY_GROUP_EDIT_OK:
+                {
+                    if (!edit_mgr) break;
+
+                    // Read group name
+                    char name[MAX_GROUP_NAME] = "";
+                    GetWindowText(hNameEdit, name, MAX_GROUP_NAME);
+                    
+                    // Validate name
+                    if (name[0] == '\0') {
+                        MessageBox(hwnd, "Please enter a group name.", 
+                                   "Invalid Input", MB_OK | MB_ICONWARNING | MB_TOPMOST);
+                        SetFocus(hNameEdit);
+                        break;
+                    }
+
+                    // Read event mask from checkboxes
+                    unsigned int mask = 0;
+                    for (int i = 0; i < NOTIFY_EVENT_COUNT; i++) {
+                        if (SendMessage(hCheckboxes[i], BM_GETCHECK, 0, 0) == BST_CHECKED) {
+                            mask |= (1 << i);
+                        }
+                    }
+
+                    bool success = false;
+
+                    if (edit_index < 0) {
+                        // Add new group
+                        int new_idx = notify_groups_add(edit_mgr, name, mask);
+                        if (new_idx >= 0) {
+                            notify_groups_save(edit_mgr);
+                            success = true;
+                        }
+                    } else {
+                        // Update existing group
+                        success = notify_groups_update(edit_mgr, edit_index, name, mask);
+                        if (success) {
+                            notify_groups_save(edit_mgr);
+                        }
+                    }
+
+                    if (success) {
+                        DestroyWindow(hwnd);
+                    } else {
+                        MessageBox(hwnd, "Failed to save group. Max groups may be reached.",
+                                   "Error", MB_OK | MB_ICONERROR | MB_TOPMOST);
+                    }
+                    break;
+                }
+
+                case IDC_NOTIFY_GROUP_EDIT_CANCEL:
+                    DestroyWindow(hwnd);
+                    break;
+            }
+            break;
+
+        case WM_DESTROY:
+            {
+                HFONT hFont = (HFONT)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+                if (hFont) DeleteObject(hFont);
+            }
+            edit_mgr = NULL;
+            edit_index = -1;
+            PostQuitMessage(0);
+            break;
+
+        case WM_CLOSE:
+            DestroyWindow(hwnd);
+            break;
+    }
+
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+void show_notify_group_edit_dialog(HWND hwnd_parent, NotifyGroupManager* mgr, int group_index) {
+    if (!mgr) return;
+
+    HINSTANCE hInstance = GetModuleHandle(NULL);
+
+    WNDCLASS wc = {0};
+    wc.lpfnWndProc = notify_group_edit_proc;
+    wc.hInstance = hInstance;
+    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
+    wc.lpszClassName = "NoSleepNotifyGroupEditDialog";
+
+    RegisterClass(&wc);
+
+    const char* title = (group_index < 0) ? "New Notification Group" : "Edit Notification Group";
+
+    // Set global context before creating window (WM_CREATE reads it)
+    g_notify_edit_ctx.mgr = mgr;
+    g_notify_edit_ctx.group_index = group_index;
+    g_notify_edit_ctx.hwnd_parent = hwnd_parent;
+
+    HWND hwndDlg = CreateWindowEx(
+        0, "NoSleepNotifyGroupEditDialog", title,
+        WS_POPUP | WS_CAPTION | WS_SYSMENU | DS_MODALFRAME,
+        CW_USEDEFAULT, CW_USEDEFAULT, 460, 400,
+        hwnd_parent, NULL, hInstance, NULL
+    );
+
+    if (hwndDlg) {
+        ShowWindow(hwndDlg, SW_SHOW);
+
+        MSG msg;
+        while (GetMessage(&msg, NULL, 0, 0)) {
+            if (!IsDialogMessage(hwndDlg, &msg)) {
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+            }
+        }
+    }
+
+    UnregisterClass("NoSleepNotifyGroupEditDialog", hInstance);
 }
 
 void tray_show_about_dialog(NoSleepTray* tray) {
@@ -3437,169 +3912,73 @@ static LRESULT CALLBACK about_dialog_proc(HWND hwnd, UINT msg, WPARAM wParam, LP
     return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
-// Update checking
+// Update checking - uses updater module
 void tray_check_for_updates(NoSleepTray* tray, bool silent) {
     if (!tray) return;
 
     const char* debug = getenv("NOSLEEP_DEBUG");
-
-    HINTERNET hSession = WinHttpOpen(L"nosleep-updater/1.0",
-        WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, NULL, NULL, 0);
-    if (!hSession) {
-        if (!silent) {
-            tray_show_notification(tray, "Update Check Failed", "Could not initialize network", false);
-        }
-        return;
+    if (debug && strcmp(debug, "1") == 0) {
+        fprintf(stderr, "[nosleep] tray_check_for_updates: checking for updates\n");
     }
 
-    HINTERNET hConnect = WinHttpConnect(hSession, L"api.github.com",
-        INTERNET_DEFAULT_HTTPS_PORT, 0);
-    if (!hConnect) {
-        WinHttpCloseHandle(hSession);
-        if (!silent) {
-            tray_show_notification(tray, "Update Check Failed", "Could not connect to server", false);
-        }
-        return;
-    }
-
-    HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET",
-        L"/repos/JohnXu22786/nosleep/releases/latest", NULL, NULL, NULL,
-        WINHTTP_FLAG_SECURE);
-    if (!hRequest) {
-        WinHttpCloseHandle(hConnect);
-        WinHttpCloseHandle(hSession);
-        if (!silent) {
-            tray_show_notification(tray, "Update Check Failed", "Could not create request", false);
-        }
-        return;
-    }
-
-    BOOL sent = WinHttpSendRequest(hRequest, NULL, 0, NULL, 0, 0, 0);
-    if (!sent) {
-        WinHttpCloseHandle(hRequest);
-        WinHttpCloseHandle(hConnect);
-        WinHttpCloseHandle(hSession);
-        if (!silent) {
-            tray_show_notification(tray, "Update Check Failed", "Could not send request", false);
-        }
-        return;
-    }
-
-    BOOL received = WinHttpReceiveResponse(hRequest, NULL);
-    if (!received) {
-        WinHttpCloseHandle(hRequest);
-        WinHttpCloseHandle(hConnect);
-        WinHttpCloseHandle(hSession);
-        if (!silent) {
-            tray_show_notification(tray, "Update Check Failed", "Could not receive response", false);
-        }
-        return;
-    }
-
-    DWORD status_code = 0;
-    DWORD status_size = sizeof(status_code);
-    WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
-        NULL, &status_code, &status_size, NULL);
-
-    if (status_code != 200) {
-        WinHttpCloseHandle(hRequest);
-        WinHttpCloseHandle(hConnect);
-        WinHttpCloseHandle(hSession);
-        if (!silent) {
-            char msg[128];
-            snprintf(msg, sizeof(msg), "Server returned status %lu", status_code);
-            tray_show_notification(tray, "Update Check Failed", msg, false);
-        }
-        return;
-    }
-
-    DWORD content_length = 0;
-    DWORD cl_size = sizeof(content_length);
-    WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_CONTENT_LENGTH | WINHTTP_QUERY_FLAG_NUMBER,
-        NULL, &content_length, &cl_size, NULL);
-
-    DWORD total_read = 0;
-    DWORD buffer_size = 4096;
-    if (content_length > 0) {
-        buffer_size = content_length + 1;
-    } else {
-        buffer_size = 8192;
-    }
-
-    char* response = (char*)malloc(buffer_size);
-    if (!response) {
-        WinHttpCloseHandle(hRequest);
-        WinHttpCloseHandle(hConnect);
-        WinHttpCloseHandle(hSession);
-        if (!silent) {
-            tray_show_notification(tray, "Update Check Failed", "Out of memory", false);
-        }
-        return;
-    }
-    memset(response, 0, buffer_size);
-
-    DWORD bytes_read = 0;
-    while (WinHttpReadData(hRequest, response + total_read, buffer_size - total_read - 1, &bytes_read) && bytes_read > 0) {
-        total_read += bytes_read;
-        if (total_read >= buffer_size - 1) {
-            buffer_size *= 2;
-            char* new_response = (char*)realloc(response, buffer_size);
-            if (!new_response) break;
-            response = new_response;
-            memset(response + total_read, 0, buffer_size - total_read);
-        }
-    }
-    response[total_read] = '\0';
-
-    WinHttpCloseHandle(hRequest);
-    WinHttpCloseHandle(hConnect);
-    WinHttpCloseHandle(hSession);
+    UpdateInfo info;
+    bool check_ok = updater_check(&info, tray->hwnd);
 
     save_last_update_check_time();
 
-    // Parse JSON for "tag_name"
-    char* tag = strstr(response, "\"tag_name\"");
-    char latest_version[64] = "";
-    if (tag) {
-        char* quote1 = strchr(tag + 10, '"');
-        if (quote1) {
-            char* quote2 = strchr(quote1 + 1, '"');
-            if (quote2) {
-                size_t len = (size_t)(quote2 - quote1 - 1);
-                if (len > 0 && len < sizeof(latest_version)) {
-                    strncpy(latest_version, quote1 + 1, len);
-                    latest_version[len] = '\0';
-                }
-            }
-        }
-    }
-
-    free(response);
-
-    if (latest_version[0] == '\0') {
+    if (!check_ok) {
         if (!silent) {
-            tray_show_notification(tray, "Update Check Failed", "Could not parse version info", false);
+            tray_show_notification_event(tray, NOTIFY_EVENT_UPDATE_CHECK_FAILED,
+                "Update Check Failed", "Could not check for updates. Check your internet connection.", false);
         }
         return;
     }
 
-    // Strip leading 'v' if present
-    const char* remote_ver = latest_version;
-    if (remote_ver[0] == 'v' || remote_ver[0] == 'V') {
-        remote_ver++;
+    if (!info.update_available) {
+        if (!silent) {
+            tray_show_notification(tray, "No Updates", 
+                "You are running the latest version (v" CURRENT_VERSION ")", false);
+        }
+        return;
     }
 
-    if (strcmp(remote_ver, CURRENT_VERSION) > 0) {
-        char msg[256];
-        snprintf(msg, sizeof(msg), "Version %s is available!\nYou have v" CURRENT_VERSION, latest_version);
-        tray_show_notification(tray, "Update Available", msg, false);
-    } else {
+    // Compare versions
+    if (updater_compare_versions(info.latest_version, CURRENT_VERSION) <= 0) {
         if (!silent) {
-            tray_show_notification(tray, "No Updates", "You are running the latest version (v" CURRENT_VERSION ")", false);
+            tray_show_notification(tray, "No Updates", 
+                "You are running the latest version (v" CURRENT_VERSION ")", false);
         }
-        if (debug) {
-            fprintf(stderr, "[nosleep] Update check: current=%s, latest=%s - up to date\n", CURRENT_VERSION, latest_version);
-        }
+        return;
+    }
+
+    // New version available - show notification
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Version %s is available! (You have v" CURRENT_VERSION ")", info.latest_version);
+        tray_show_notification_event(tray, NOTIFY_EVENT_UPDATE_AVAILABLE, "Update Available", msg, false);
+    }
+
+    // Ask user if they want to download
+    bool want_download = updater_show_prompt_dialog(tray->hwnd, &info);
+    if (!want_download) {
+        return;
+    }
+
+    // Get current executable path
+    char* exe_path = get_exe_path();
+    if (!exe_path) {
+        MessageBox(tray->hwnd, "Could not determine executable path.", 
+                   "Update Failed", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        return;
+    }
+
+    // Download and install
+    bool update_started = updater_download_and_install(&info, exe_path, tray->hwnd);
+    free(exe_path);
+
+    if (update_started) {
+        // Exit the application so the update can complete
+        PostMessage(tray->hwnd, WM_CLOSE, 0, 0);
     }
 }
 

--- a/src/tray.h
+++ b/src/tray.h
@@ -5,6 +5,7 @@
 
 #include <windows.h>
 #include <stdbool.h>
+#include "notify_groups.h"
 
 // Atomic operation macros for thread-safe flag access
 #ifdef __GNUC__
@@ -109,8 +110,9 @@ typedef struct NoSleepTray {
     bool check_updates_on_startup; // Whether to check for updates on startup
     int auto_check_interval;    // 0=Never, 1=Daily, 2=Weekly
     UINT_PTR update_timer_id;   // Timer ID for periodic update checks
-    int notification_mode;      // 0=all, 1=critical only, 2=none
+    int notification_mode;      // 0=all, 1=critical only, 2=none (legacy, use notify_groups instead)
     bool add_to_path;           // Whether to add nosleep directory to environment PATH
+    NotifyGroupManager notify_groups; // Notification group manager for per-event filtering
 } NoSleepTray;
 
 // Function prototypes
@@ -125,7 +127,9 @@ void tray_stop_nosleep(NoSleepTray* tray, bool timer_expired, bool suppress_noti
 void tray_set_duration(NoSleepTray* tray, int minutes);
 
 void tray_update_icon(NoSleepTray* tray);
+// Includes notification event type for per-event filtering
 void tray_show_notification(NoSleepTray* tray, const char* title, const char* message, bool critical);
+void tray_show_notification_event(NoSleepTray* tray, int event_type, const char* title, const char* message, bool critical);
 void tray_update_stop_menu_item(NoSleepTray* tray);
 void tray_set_startup_enabled(NoSleepTray* tray, bool enable);
 void tray_set_add_to_path(NoSleepTray* tray, bool enable);

--- a/src/updater.c
+++ b/src/updater.c
@@ -1,0 +1,760 @@
+// Updater implementation for nosleep
+#include "updater.h"
+#include "constants.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <winhttp.h>
+
+// GitHub API endpoint
+#define GITHUB_API_HOST L"api.github.com"
+#define GITHUB_API_PATH L"/repos/JohnXu22786/nosleep/releases/latest"
+
+// Forward declarations
+static char* http_get_json(HWND hwnd_parent, const wchar_t* host, const wchar_t* path, 
+                            bool* success, const char** error_msg);
+static bool download_file(const char* url, const char* output_path);
+static bool create_update_batch_script(const char* current_exe_path, 
+                                        const char* downloaded_path,
+                                        const char* exe_name,
+                                        char* script_path, size_t script_path_size);
+static char* get_exe_name_from_path(const char* path);
+static char* get_temp_path_for(const char* prefix);
+
+// Compare two version strings (e.g., "2.0.0" > "1.5.0")
+// Returns: 1 if v1 > v2, 0 if equal, -1 if v1 < v2
+int updater_compare_versions(const char* v1, const char* v2) {
+    if (!v1 || !v2) return 0;
+    
+    // Strip leading 'v' or 'V'
+    if (v1[0] == 'v' || v1[0] == 'V') v1++;
+    if (v2[0] == 'v' || v2[0] == 'V') v2++;
+    
+    // Parse major.minor.patch
+    int maj1 = 0, min1 = 0, pat1 = 0;
+    int maj2 = 0, min2 = 0, pat2 = 0;
+    
+    sscanf(v1, "%d.%d.%d", &maj1, &min1, &pat1);
+    sscanf(v2, "%d.%d.%d", &maj2, &min2, &pat2);
+    
+    if (maj1 > maj2) return 1;
+    if (maj1 < maj2) return -1;
+    if (min1 > min2) return 1;
+    if (min1 < min2) return -1;
+    if (pat1 > pat2) return 1;
+    if (pat1 < pat2) return -1;
+    return 0;
+}
+
+// Parse GitHub API response JSON
+bool updater_parse_response(const char* json_response, UpdateInfo* info) {
+    if (!json_response || !info) return false;
+    
+    memset(info, 0, sizeof(UpdateInfo));
+    
+    // Parse "tag_name"
+    const char* tag = strstr(json_response, "\"tag_name\"");
+    if (!tag) return false;
+    
+    const char* quote1 = strchr(tag + 10, '"');
+    if (!quote1) return false;
+    
+    const char* quote2 = strchr(quote1 + 1, '"');
+    if (!quote2) return false;
+    
+    size_t len = (size_t)(quote2 - quote1 - 1);
+    if (len == 0 || len >= sizeof(info->tag_name)) return false;
+    
+    strncpy(info->tag_name, quote1 + 1, len);
+    info->tag_name[len] = '\0';
+    
+    // Copy to latest_version, stripping leading v/V
+    const char* ver = info->tag_name;
+    if (ver[0] == 'v' || ver[0] == 'V') ver++;
+    strncpy(info->latest_version, ver, sizeof(info->latest_version) - 1);
+    info->latest_version[sizeof(info->latest_version) - 1] = '\0';
+    
+    // Parse "assets" array for browser_download_url
+    // Look for .exe file in the assets
+    const char* assets = strstr(json_response, "\"assets\"");
+    if (assets) {
+        // Search for browser_download_url within assets
+        const char* search_pos = assets;
+        while (1) {
+            const char* url_key = strstr(search_pos, "\"browser_download_url\"");
+            if (!url_key) break;
+            
+            const char* uq1 = strchr(url_key + 20, '"');
+            if (!uq1) break;
+            
+            const char* uq2 = strchr(uq1 + 1, '"');
+            if (!uq2) break;
+            
+            size_t url_len = (size_t)(uq2 - uq1 - 1);
+            if (url_len > 0 && url_len < sizeof(info->download_url) - 1) {
+                strncpy(info->download_url, uq1 + 1, url_len);
+                info->download_url[url_len] = '\0';
+                
+                // Check if this URL points to an EXE file
+                if (strstr(info->download_url, ".exe") != NULL) {
+                    info->update_available = true;
+                    return true;
+                }
+            }
+            
+            search_pos = uq2 + 1;
+        }
+    }
+    
+    // If we found tag_name but no EXE asset, still mark as available
+    // (maybe the asset URL pattern is different)
+    if (info->tag_name[0] != '\0') {
+        info->update_available = true;
+        // Construct fallback URL
+        snprintf(info->download_url, sizeof(info->download_url),
+            "https://github.com/JohnXu22786/nosleep/releases/download/%s/nosleep-%s.exe",
+            info->tag_name, info->tag_name);
+        return true;
+    }
+    
+    return false;
+}
+
+// Check for updates against GitHub releases
+bool updater_check(UpdateInfo* info, HWND hwnd_parent) {
+    if (!info) return false;
+    
+    memset(info, 0, sizeof(UpdateInfo));
+    (void)hwnd_parent; // Unused in current implementation
+    
+    bool success = false;
+    const char* error_detail = NULL;
+    
+    char* response = http_get_json(hwnd_parent, GITHUB_API_HOST, GITHUB_API_PATH, 
+                                    &success, &error_detail);
+    if (!success || !response) {
+        if (response) free(response);
+        return false;
+    }
+    
+    bool parsed = updater_parse_response(response, info);
+    free(response);
+    
+    return parsed;
+}
+
+// Show the "Update Available" dialog
+bool updater_show_prompt_dialog(HWND hwnd_parent, UpdateInfo* info) {
+    if (!info || !info->update_available) return false;
+    
+    char msg[512];
+    snprintf(msg, sizeof(msg), 
+        "Version %s is now available (you have v" CURRENT_VERSION ").\n\n"
+        "Do you want to download and install the update?\n\n"
+        "The application will close automatically during the update.",
+        info->latest_version);
+    
+    char title[128];
+    snprintf(title, sizeof(title), "Update Available - nosleep");
+    
+    int result = MessageBox(hwnd_parent, msg, title, 
+                             MB_YESNO | MB_ICONQUESTION | MB_DEFBUTTON1 | MB_TOPMOST);
+    
+    return (result == IDYES);
+}
+
+// Download a new version and perform the update
+bool updater_download_and_install(UpdateInfo* info, const char* current_exe_path, HWND hwnd_parent) {
+    if (!info || !current_exe_path) return false;
+    
+    // Get temp path for downloaded file
+    char* temp_path = get_temp_path_for("nosleep_update");
+    if (!temp_path) return false;
+    
+    // Show downloading message
+    char download_msg[256];
+    snprintf(download_msg, sizeof(download_msg), 
+        "Downloading nosleep %s...\nPlease wait.", info->latest_version);
+    
+    // Create a simple status dialog
+    HWND hStatus = CreateWindowEx(0, "STATIC", download_msg,
+        WS_POPUP | WS_CAPTION | WS_SYSMENU | DS_MODALFRAME,
+        CW_USEDEFAULT, CW_USEDEFAULT, 350, 100,
+        hwnd_parent, NULL, GetModuleHandle(NULL), NULL);
+    
+    HFONT hFont = CreateFont(16, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
+        DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+        CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, "Segoe UI");
+    if (hFont) {
+        SendMessage(hStatus, WM_SETFONT, (WPARAM)hFont, TRUE);
+    }
+    
+    if (hStatus) {
+        // Center on screen
+        RECT rc;
+        GetWindowRect(hStatus, &rc);
+        int sw = GetSystemMetrics(SM_CXSCREEN);
+        int sh = GetSystemMetrics(SM_CYSCREEN);
+        SetWindowPos(hStatus, NULL, 
+            (sw - (rc.right - rc.left)) / 2,
+            (sh - (rc.bottom - rc.top)) / 2,
+            0, 0, SWP_NOSIZE | SWP_NOZORDER);
+        ShowWindow(hStatus, SW_SHOW);
+        UpdateWindow(hStatus);
+    }
+    
+    // Download the file
+    bool download_ok = download_file(info->download_url, temp_path);
+    
+    if (hStatus) {
+        DestroyWindow(hStatus);
+    }
+    if (hFont) {
+        DeleteObject(hFont);
+    }
+    
+    if (!download_ok) {
+        char err_msg[512];
+        snprintf(err_msg, sizeof(err_msg), 
+            "Failed to download update from:\n%s\n\nPlease check your internet connection and try again.",
+            info->download_url);
+        MessageBox(hwnd_parent, err_msg, "Download Failed", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        free(temp_path);
+        return false;
+    }
+    
+    // Verify the downloaded file exists and has size > 0
+    WIN32_FILE_ATTRIBUTE_DATA fad;
+    if (!GetFileAttributesEx(temp_path, GetFileExInfoStandard, &fad) || 
+        fad.nFileSizeLow == 0) {
+        MessageBox(hwnd_parent, "Downloaded file appears to be invalid (0 bytes).\nPlease try again.",
+            "Update Failed", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        DeleteFile(temp_path);
+        free(temp_path);
+        return false;
+    }
+    
+    // Get the EXE name from current path
+    char* exe_name = get_exe_name_from_path(current_exe_path);
+    if (!exe_name) {
+        free(temp_path);
+        return false;
+    }
+    
+    // Create update batch script in temp directory
+    char script_path[MAX_PATH];
+    if (!create_update_batch_script(current_exe_path, temp_path, exe_name, 
+                                    script_path, sizeof(script_path))) {
+        free(exe_name);
+        free(temp_path);
+        MessageBox(hwnd_parent, "Failed to create update script.", 
+            "Update Failed", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        return false;
+    }
+    
+    // Show notification that update is about to begin
+    char notify_msg[256];
+    snprintf(notify_msg, sizeof(notify_msg), 
+        "Update downloaded. The application will now close to complete the update.");
+    MessageBox(hwnd_parent, notify_msg, "Update Ready", 
+        MB_OK | MB_ICONINFORMATION | MB_TOPMOST);
+    
+    // Launch the update batch script
+    SHELLEXECUTEINFO sei = {0};
+    sei.cbSize = sizeof(SHELLEXECUTEINFO);
+    sei.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC;
+    sei.lpFile = script_path;
+    sei.nShow = SW_HIDE;
+    
+    if (!ShellExecuteEx(&sei)) {
+        free(exe_name);
+        free(temp_path);
+        MessageBox(hwnd_parent, "Failed to launch update process.\nPlease run the update manually.",
+            "Update Failed", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        return false;
+    }
+    
+    free(exe_name);
+    free(temp_path);
+    
+    // Signal the application to exit (caller should handle this)
+    return true;
+}
+
+// --- Helper functions ---
+
+static char* get_exe_name_from_path(const char* path) {
+    if (!path) return NULL;
+    
+    const char* last_backslash = strrchr(path, '\\');
+    if (last_backslash) {
+        return _strdup(last_backslash + 1);
+    }
+    return _strdup(path);
+}
+
+static char* get_temp_path_for(const char* prefix) {
+    char temp_dir[MAX_PATH];
+    DWORD len = GetTempPath(MAX_PATH, temp_dir);
+    if (len == 0 || len >= MAX_PATH) return NULL;
+    
+    char* path = (char*)malloc(MAX_PATH);
+    if (!path) return NULL;
+    
+    // Ensure unique name
+    char unique_name[64];
+    snprintf(unique_name, sizeof(unique_name), "%s_%lu_%lu.exe", 
+             prefix, GetCurrentProcessId(), GetTickCount());
+    
+    snprintf(path, MAX_PATH, "%s%s", temp_dir, unique_name);
+    return path;
+}
+
+// Fetch JSON from GitHub API via HTTPS
+static char* http_get_json(HWND hwnd_parent, const wchar_t* host, const wchar_t* path, 
+                            bool* success, const char** error_msg) {
+    *success = false;
+    if (error_msg) *error_msg = NULL;
+    (void)hwnd_parent;
+    
+    HINTERNET hSession = WinHttpOpen(L"nosleep-updater/1.0",
+        WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, NULL, NULL, 0);
+    if (!hSession) {
+        if (error_msg) *error_msg = "Could not initialize network";
+        return NULL;
+    }
+    
+    HINTERNET hConnect = WinHttpConnect(hSession, host, INTERNET_DEFAULT_HTTPS_PORT, 0);
+    if (!hConnect) {
+        WinHttpCloseHandle(hSession);
+        if (error_msg) *error_msg = "Could not connect to server";
+        return NULL;
+    }
+    
+    HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET", path, 
+        NULL, NULL, NULL, WINHTTP_FLAG_SECURE);
+    if (!hRequest) {
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        if (error_msg) *error_msg = "Could not create request";
+        return NULL;
+    }
+    
+    // Set timeout to 10 seconds
+    DWORD timeout = 10000;
+    WinHttpSetOption(hRequest, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
+    WinHttpSetOption(hRequest, WINHTTP_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
+    WinHttpSetOption(hRequest, WINHTTP_OPTION_SEND_TIMEOUT, &timeout, sizeof(timeout));
+    
+    BOOL sent = WinHttpSendRequest(hRequest, NULL, 0, NULL, 0, 0, 0);
+    if (!sent) {
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        if (error_msg) *error_msg = "Could not send request";
+        return NULL;
+    }
+    
+    BOOL received = WinHttpReceiveResponse(hRequest, NULL);
+    if (!received) {
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        if (error_msg) *error_msg = "Could not receive response";
+        return NULL;
+    }
+    
+    DWORD status_code = 0;
+    DWORD status_size = sizeof(status_code);
+    WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+        NULL, &status_code, &status_size, NULL);
+    
+    // Follow redirects (GitHub API may redirect)
+    int redirect_count = 0;
+    while ((status_code == 301 || status_code == 302 || status_code == 307 || status_code == 308) && 
+           redirect_count < 5) {
+        // Get redirect URL
+        wchar_t redirect_url[2048] = {0};
+        DWORD url_size = sizeof(redirect_url);
+        WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_LOCATION,
+            NULL, redirect_url, &url_size, NULL);
+        
+        if (redirect_url[0] == L'\0') break;
+        
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        
+        // Parse new URL
+        URL_COMPONENTS newUrlComp = {0};
+        newUrlComp.dwStructSize = sizeof(newUrlComp);
+        wchar_t newHost[256] = {0};
+        wchar_t newPath[2048] = {0};
+        newUrlComp.lpszHostName = newHost;
+        newUrlComp.dwHostNameLength = 256;
+        newUrlComp.lpszUrlPath = newPath;
+        newUrlComp.dwUrlPathLength = 2048;
+        
+        if (!WinHttpCrackUrl(redirect_url, 0, 0, &newUrlComp)) break;
+        
+        hConnect = WinHttpConnect(hSession, newHost,
+            newUrlComp.nScheme == INTERNET_SCHEME_HTTPS ? INTERNET_DEFAULT_HTTPS_PORT : INTERNET_DEFAULT_HTTP_PORT, 0);
+        if (!hConnect) break;
+        
+        DWORD newFlags = WINHTTP_FLAG_REFRESH;
+        if (newUrlComp.nScheme == INTERNET_SCHEME_HTTPS) newFlags |= WINHTTP_FLAG_SECURE;
+        
+        hRequest = WinHttpOpenRequest(hConnect, L"GET", newPath, NULL, NULL, NULL, newFlags);
+        if (!hRequest) {
+            WinHttpCloseHandle(hConnect);
+            hConnect = NULL;
+            break;
+        }
+        
+        DWORD timeout = 10000;
+        WinHttpSetOption(hRequest, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
+        WinHttpSetOption(hRequest, WINHTTP_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
+        
+        if (!WinHttpSendRequest(hRequest, NULL, 0, NULL, 0, 0, 0)) break;
+        if (!WinHttpReceiveResponse(hRequest, NULL)) break;
+        
+        status_size = sizeof(status_code);
+        WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+            NULL, &status_code, &status_size, NULL);
+        
+        redirect_count++;
+    }
+    
+    if (status_code != 200) {
+        WinHttpCloseHandle(hRequest);
+        if (hConnect) WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        if (error_msg) *error_msg = "Server returned non-200 status";
+        return NULL;
+    }
+    
+    DWORD content_length = 0;
+    DWORD cl_size = sizeof(content_length);
+    WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_CONTENT_LENGTH | WINHTTP_QUERY_FLAG_NUMBER,
+        NULL, &content_length, &cl_size, NULL);
+    
+    DWORD total_read = 0;
+    DWORD buffer_size = 4096;
+    if (content_length > 0) {
+        buffer_size = content_length + 1;
+    } else {
+        buffer_size = 8192;
+    }
+    
+    char* response = (char*)malloc(buffer_size);
+    if (!response) {
+        WinHttpCloseHandle(hRequest);
+        if (hConnect) WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        if (error_msg) *error_msg = "Out of memory";
+        return NULL;
+    }
+    memset(response, 0, buffer_size);
+    
+    DWORD bytes_read = 0;
+    while (WinHttpReadData(hRequest, response + total_read, 
+                           buffer_size - total_read - 1, &bytes_read) && bytes_read > 0) {
+        total_read += bytes_read;
+        if (total_read >= buffer_size - 1) {
+            buffer_size *= 2;
+            char* new_response = (char*)realloc(response, buffer_size);
+            if (!new_response) {
+                // realloc failed - free original buffer and abort
+                free(response);
+                WinHttpCloseHandle(hRequest);
+                if (hConnect) WinHttpCloseHandle(hConnect);
+                WinHttpCloseHandle(hSession);
+                if (error_msg) *error_msg = "Out of memory during download";
+                return NULL;
+            }
+            response = new_response;
+            memset(response + total_read, 0, buffer_size - total_read);
+        }
+    }
+    response[total_read] = '\0';
+    
+    WinHttpCloseHandle(hRequest);
+    if (hConnect) WinHttpCloseHandle(hConnect);
+    WinHttpCloseHandle(hSession);
+    
+    *success = true;
+    return response;
+}
+
+// Download a file from URL to local path
+static bool download_file(const char* url, const char* output_path) {
+    if (!url || !output_path) return false;
+    
+    // Parse the URL
+    // Expected format: https://github.com/.../nosleep-vX.X.X.exe
+    wchar_t wurl[2048];
+    MultiByteToWideChar(CP_UTF8, 0, url, -1, wurl, 2048);
+    
+    // Parse URL to extract host, path
+    URL_COMPONENTS urlComp = {0};
+    urlComp.dwStructSize = sizeof(urlComp);
+    
+    wchar_t hostName[256] = {0};
+    wchar_t urlPath[2048] = {0};
+    
+    urlComp.lpszHostName = hostName;
+    urlComp.dwHostNameLength = 256;
+    urlComp.lpszUrlPath = urlPath;
+    urlComp.dwUrlPathLength = 2048;
+    
+    if (!WinHttpCrackUrl(wurl, 0, 0, &urlComp)) {
+        return false;
+    }
+    
+    HINTERNET hSession = WinHttpOpen(L"nosleep-updater/1.0",
+        WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, NULL, NULL, 0);
+    if (!hSession) return false;
+    
+    HINTERNET hConnect = WinHttpConnect(hSession, hostName, 
+        urlComp.nScheme == INTERNET_SCHEME_HTTPS ? INTERNET_DEFAULT_HTTPS_PORT : INTERNET_DEFAULT_HTTP_PORT, 0);
+    if (!hConnect) {
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
+    
+    DWORD flags = WINHTTP_FLAG_REFRESH;
+    if (urlComp.nScheme == INTERNET_SCHEME_HTTPS) {
+        flags |= WINHTTP_FLAG_SECURE;
+    }
+    
+    HINTERNET hRequest = WinHttpOpenRequest(hConnect, L"GET", urlPath,
+        NULL, NULL, NULL, flags);
+    if (!hRequest) {
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
+    
+    // Set timeout
+    DWORD timeout = 30000; // 30 seconds for download
+    WinHttpSetOption(hRequest, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
+    WinHttpSetOption(hRequest, WINHTTP_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
+    
+    // Send request
+    if (!WinHttpSendRequest(hRequest, NULL, 0, NULL, 0, 0, 0)) {
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
+    
+    if (!WinHttpReceiveResponse(hRequest, NULL)) {
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
+    
+    DWORD status_code = 0;
+    DWORD status_size = sizeof(status_code);
+    WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+        NULL, &status_code, &status_size, NULL);
+    
+    // GitHub releases may redirect; follow redirects manually
+    int redirect_count = 0;
+    while ((status_code == 301 || status_code == 302 || status_code == 307 || status_code == 308) && 
+           redirect_count < 5) {
+        // Get redirect URL
+        wchar_t redirect_url[2048] = {0};
+        DWORD url_size = sizeof(redirect_url);
+        WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_LOCATION,
+            NULL, redirect_url, &url_size, NULL);
+        
+        if (redirect_url[0] == L'\0') {
+            hRequest = NULL;
+            hConnect = NULL;
+            break;
+        }
+        
+        WinHttpCloseHandle(hRequest);
+        hRequest = NULL;
+        WinHttpCloseHandle(hConnect);
+        hConnect = NULL;
+        
+        // Parse new URL
+        URL_COMPONENTS newUrlComp = {0};
+        newUrlComp.dwStructSize = sizeof(newUrlComp);
+        wchar_t newHost[256] = {0};
+        wchar_t newPath[2048] = {0};
+        newUrlComp.lpszHostName = newHost;
+        newUrlComp.dwHostNameLength = 256;
+        newUrlComp.lpszUrlPath = newPath;
+        newUrlComp.dwUrlPathLength = 2048;
+        
+        if (!WinHttpCrackUrl(redirect_url, 0, 0, &newUrlComp)) {
+            hRequest = NULL;
+            hConnect = NULL;
+            break;
+        }
+        
+        hConnect = WinHttpConnect(hSession, newHost,
+            newUrlComp.nScheme == INTERNET_SCHEME_HTTPS ? INTERNET_DEFAULT_HTTPS_PORT : INTERNET_DEFAULT_HTTP_PORT, 0);
+        if (!hConnect) {
+            hRequest = NULL;
+            break;
+        }
+        
+        DWORD newFlags = WINHTTP_FLAG_REFRESH;
+        if (newUrlComp.nScheme == INTERNET_SCHEME_HTTPS) newFlags |= WINHTTP_FLAG_SECURE;
+        
+        hRequest = WinHttpOpenRequest(hConnect, L"GET", newPath, NULL, NULL, NULL, newFlags);
+        if (!hRequest) {
+            WinHttpCloseHandle(hConnect);
+            hConnect = NULL;
+            break;
+        }
+        
+        WinHttpSetOption(hRequest, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
+        WinHttpSetOption(hRequest, WINHTTP_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
+        
+        if (!WinHttpSendRequest(hRequest, NULL, 0, NULL, 0, 0, 0)) break;
+        if (!WinHttpReceiveResponse(hRequest, NULL)) break;
+        
+        status_size = sizeof(status_code);
+        WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+            NULL, &status_code, &status_size, NULL);
+        
+        redirect_count++;
+    }
+    
+    if (status_code != 200) {
+        if (hRequest) WinHttpCloseHandle(hRequest);
+        if (hConnect) WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
+    
+    // Open output file
+    HANDLE hFile = CreateFile(output_path, GENERIC_WRITE, 0, NULL,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
+    
+    // Read data and write to file
+    DWORD buffer_size = 65536;
+    char* buffer = (char*)malloc(buffer_size);
+    if (!buffer) {
+        CloseHandle(hFile);
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
+    
+    DWORD bytes_read = 0;
+    DWORD total_bytes = 0;
+    bool write_error = false;
+    while (WinHttpReadData(hRequest, buffer, buffer_size, &bytes_read) && bytes_read > 0) {
+        DWORD bytes_written = 0;
+        if (!WriteFile(hFile, buffer, bytes_read, &bytes_written, NULL) || bytes_written != bytes_read) {
+            write_error = true;
+            break;
+        }
+        total_bytes += bytes_written;
+    }
+    
+    free(buffer);
+    CloseHandle(hFile);
+    WinHttpCloseHandle(hRequest);
+    if (hConnect) WinHttpCloseHandle(hConnect);
+    WinHttpCloseHandle(hSession);
+    
+    // Return true only if we wrote data and had no write errors
+    return total_bytes > 0 && !write_error;
+}
+
+// Create a batch script that:
+// 1. Waits for the parent process to exit
+// 2. Replaces the old EXE with the downloaded one (preserving original filename)
+// 3. Starts the new EXE
+// 4. Deletes itself
+static bool create_update_batch_script(const char* current_exe_path, 
+                                        const char* downloaded_path,
+                                        const char* exe_name,
+                                        char* script_path, size_t script_path_size) {
+    if (!current_exe_path || !downloaded_path || !exe_name) return false;
+    
+    // Create script in temp directory
+    char temp_dir[MAX_PATH];
+    DWORD len = GetTempPath(MAX_PATH, temp_dir);
+    if (len == 0 || len >= MAX_PATH) return false;
+    
+    snprintf(script_path, script_path_size, "%snosleep_update_%lu.bat", 
+             temp_dir, GetTickCount());
+    
+    // Build the batch script
+    // The script:
+    // 1. Waits for nosleep to exit by polling tasklist
+    // 2. Copies the downloaded file over the current EXE (renaming it)
+    // 3. Starts the new EXE with the same arguments
+    // 4. Deletes itself
+    
+    char script_content[4096];
+    int written = snprintf(script_content, sizeof(script_content),
+        "@echo off\r\n"
+        "title Updating nosleep...\r\n"
+        "echo Waiting for nosleep to close...\r\n"
+        ":WAITLOOP\r\n"
+        "timeout /t 2 /nobreak > nul\r\n"
+        "tasklist /FI \"IMAGENAME eq %s\" 2>nul | find /I \"%s\" > nul\r\n"
+        "if errorlevel 1 goto REPLACE\r\n"
+        "goto WAITLOOP\r\n"
+        ":REPLACE\r\n"
+        "echo Replacing executable...\r\n"
+        "copy /Y \"%s\" \"%s\" > nul\r\n"
+        "if errorlevel 1 (\r\n"
+        "    echo Failed to update. The file may be in use.\r\n"
+        "    echo.\r\n"
+        "    echo The downloaded file is at:\r\n"
+        "    echo   %s\r\n"
+        "    echo.\r\n"
+        "    pause\r\n"
+        "    exit /b 1\r\n"
+        ")\r\n"
+        "echo Update complete! Starting nosleep...\r\n"
+        "start \"\" \"%s\"\r\n"
+        "echo Cleaning up...\r\n"
+        "del \"%s\" > nul 2>&1\r\n"
+        "del \"%%~f0\" > nul 2>&1\r\n",
+        exe_name,                    // for tasklist filter
+        exe_name,                    // for find
+        downloaded_path,             // source file to copy from
+        current_exe_path,            // destination (original EXE path)
+        downloaded_path,             // info message about temp file
+        current_exe_path,            // to start the new version
+        downloaded_path              // delete temp file
+    );
+    
+    if (written <= 0 || (size_t)written >= sizeof(script_content)) {
+        return false;
+    }
+    
+    // Write script file
+    HANDLE hFile = CreateFile(script_path, GENERIC_WRITE, 0, NULL,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) return false;
+    
+    DWORD bytes_written;
+    BOOL write_ok = WriteFile(hFile, script_content, (DWORD)strlen(script_content), &bytes_written, NULL);
+    CloseHandle(hFile);
+    
+    if (!write_ok || bytes_written != strlen(script_content)) {
+        DeleteFile(script_path);
+        return false;
+    }
+    
+    return true;
+}

--- a/src/updater.h
+++ b/src/updater.h
@@ -1,0 +1,41 @@
+// Updater module for nosleep
+// Handles checking for updates, downloading, and installing new versions
+#ifndef UPDATER_H
+#define UPDATER_H
+
+#include <windows.h>
+#include <stdbool.h>
+
+// Struct to hold update information
+typedef struct {
+    char latest_version[64];   // Latest version string (e.g., "2.0.0")
+    char download_url[512];    // Direct download URL for the EXE asset
+    char tag_name[64];         // Full tag name (e.g., "v2.0.0")
+    bool update_available;     // Whether an update is available
+} UpdateInfo;
+
+// Check for updates against GitHub releases
+// Returns true if check was successful (result in info)
+// silent: if true, don't show error notifications
+bool updater_check(UpdateInfo* info, HWND hwnd_parent);
+
+// Download a new version and perform the update
+// current_exe_path: full path to the current executable
+// info: update information from updater_check
+// HWND: parent window for any dialogs
+// Returns true if update process started successfully
+bool updater_download_and_install(UpdateInfo* info, const char* current_exe_path, HWND hwnd_parent);
+
+// Parse the GitHub API response JSON to extract version and download URL
+// Returns true if parsing was successful
+bool updater_parse_response(const char* json_response, UpdateInfo* info);
+
+// Compare two version strings (e.g., "2.0.0" > "1.5.0")
+// Returns: 1 if v1 > v2, 0 if equal, -1 if v1 < v2
+int updater_compare_versions(const char* v1, const char* v2);
+
+// Show the "Update Available" dialog and return user's choice
+// Returns true if user wants to download
+bool updater_show_prompt_dialog(HWND hwnd_parent, UpdateInfo* info);
+
+#endif // UPDATER_H

--- a/test_notification_groups.sh
+++ b/test_notification_groups.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+# Test: Notification group data structure and version comparison
+# Tests the core logic of the new notification group system
+# and the update version comparison
+
+set -euo pipefail
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+
+# Create a temp dir
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+# If compiling on Linux with MinGW, skip tests that need compilation
+CAN_COMPILE=false
+if command -v x86_64-w64-mingw32-gcc &> /dev/null; then
+    CAN_COMPILE=true
+elif command -v gcc &> /dev/null; then
+    # For local testing we might have gcc
+    # But we can't link Win32 APIs, so compile only logic tests
+    CAN_COMPILE=true
+fi
+
+# === Test 1: Version comparison logic ===
+cat > "$TMPDIR/test_version_compare.c" << 'EOF'
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+// Simulate the version comparison logic that will be in the update feature
+// Returns: 1 if new_version > current_version, 0 if equal, -1 if new_version < current_version
+int compare_versions(const char* v1, const char* v2) {
+    // Strip leading 'v' or 'V'
+    if (v1[0] == 'v' || v1[0] == 'V') v1++;
+    if (v2[0] == 'v' || v2[0] == 'V') v2++;
+    
+    // Parse major.minor.patch
+    int maj1 = 0, min1 = 0, pat1 = 0;
+    int maj2 = 0, min2 = 0, pat2 = 0;
+    
+    sscanf(v1, "%d.%d.%d", &maj1, &min1, &pat1);
+    sscanf(v2, "%d.%d.%d", &maj2, &min2, &pat2);
+    
+    if (maj1 > maj2) return 1;
+    if (maj1 < maj2) return -1;
+    if (min1 > min2) return 1;
+    if (min1 < min2) return -1;
+    if (pat1 > pat2) return 1;
+    if (pat1 < pat2) return -1;
+    return 0;
+}
+
+int main() {
+    int failures = 0;
+    
+    // Test 1: newer version
+    if (compare_versions("2.0.0", "1.0.0") != 1) {
+        printf("FAIL: 2.0.0 should be > 1.0.0\n");
+        failures++;
+    }
+    
+    // Test 2: older version
+    if (compare_versions("1.0.0", "2.0.0") != -1) {
+        printf("FAIL: 1.0.0 should be < 2.0.0\n");
+        failures++;
+    }
+    
+    // Test 3: equal
+    if (compare_versions("1.2.3", "1.2.3") != 0) {
+        printf("FAIL: 1.2.3 should equal 1.2.3\n");
+        failures++;
+    }
+    
+    // Test 4: with leading v
+    if (compare_versions("v2.0.0", "1.0.0") != 1) {
+        printf("FAIL: v2.0.0 should be > 1.0.0\n");
+        failures++;
+    }
+    
+    // Test 5: minor version difference
+    if (compare_versions("1.3.0", "1.2.9") != 1) {
+        printf("FAIL: 1.3.0 should be > 1.2.9\n");
+        failures++;
+    }
+    
+    // Test 6: patch version difference
+    if (compare_versions("1.0.1", "1.0.0") != 1) {
+        printf("FAIL: 1.0.1 should be > 1.0.0\n");
+        failures++;
+    }
+    
+    // Test 7: with leading V (uppercase)
+    if (compare_versions("V1.0.0", "0.9.9") != 1) {
+        printf("FAIL: V1.0.0 should be > 0.9.9\n");
+        failures++;
+    }
+    
+    // Test 8: major version update
+    if (compare_versions("2.1.0", "1.9.9") != 1) {
+        printf("FAIL: 2.1.0 should be > 1.9.9\n");
+        failures++;
+    }
+    
+    return failures;
+}
+EOF
+
+if gcc -o "$TMPDIR/test_version_compare" "$TMPDIR/test_version_compare.c"; then
+    RESULT=$("$TMPDIR/test_version_compare")
+    if [ -z "$RESULT" ]; then
+        pass "Version comparison: all 8 cases correct"
+    else
+        fail "Version comparison: $RESULT"
+    fi
+else
+    fail "Version comparison test failed to compile"
+fi
+
+# === Test 2: Update batch script generation ===
+cat > "$TMPDIR/test_update_batch_gen.c" << 'EOF'
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+// Simulate the batch script generation logic
+// The batch script needs to:
+// 1. Wait for the parent process to exit
+// 2. Replace the old EXE with the downloaded one (rename to original name)
+// 3. Launch the new EXE
+// 4. Delete itself
+
+char* generate_update_script(const char* current_exe_path, 
+                              const char* downloaded_temp_path,
+                              const char* original_exe_name) {
+    // Calculate required buffer size
+    const char* template = 
+        "@echo off\r\n"
+        "title Updating nosleep...\r\n"
+        "echo Waiting for nosleep to exit...\r\n"
+        ":waitloop\r\n"
+        "ping -n 2 127.0.0.1 > nul\r\n"
+        "tasklist /FI \"IMAGENAME eq %s\" 2>nul | find /I \"%s\" > nul\r\n"
+        "if errorlevel 1 goto replace\r\n"
+        "goto waitloop\r\n"
+        ":\r\n"
+        ":replace\r\n"
+        "echo Replacing executable...\r\n"
+        "move /Y \"%s\" \"%s\" > nul\r\n"
+        "if errorlevel 1 (\r\n"
+        "    echo Failed to replace executable.\r\n"
+        "    pause\r\n"
+        "    exit /b 1\r\n"
+        ")\r\n"
+        "echo Starting nosleep...\r\n"
+        "start \"\" \"%s\"\r\n"
+        "echo Done.\r\n"
+        "del \"%%~f0\"\r\n";
+    
+    // Estimate size: template + all strings + overhead
+    size_t size = strlen(template) + strlen(current_exe_path) * 3 
+                  + strlen(downloaded_temp_path) + strlen(original_exe_name) + 256;
+    char* script = (char*)malloc(size);
+    if (!script) return NULL;
+    
+    // Get just the executable name from path
+    const char* exe_name = original_exe_name;
+    
+    snprintf(script, size, template, 
+             exe_name,           // for tasklist filter
+             exe_name,           // for find
+             downloaded_temp_path, // source
+             current_exe_path,     // destination
+             current_exe_path);    // to launch
+    
+    return script;
+}
+
+int main() {
+    int failures = 0;
+    
+    char* script = generate_update_script(
+        "C:\\Users\\test\\AppData\\Local\\nosleep.exe",
+        "C:\\Users\\test\\AppData\\Local\\Temp\\nosleep_v2.0.0.exe",
+        "nosleep.exe"
+    );
+    
+    if (!script) {
+        printf("FAIL: Script generation returned NULL\n");
+        return 1;
+    }
+    
+    // Check the script contains key elements
+    if (strstr(script, "move /Y") == NULL) {
+        printf("FAIL: Script missing move command\n");
+        failures++;
+    }
+    
+    if (strstr(script, "nosleep.exe") == NULL) {
+        printf("FAIL: Script missing executable name\n");
+        failures++;
+    }
+    
+    if (strstr(script, "Waiting for nosleep") == NULL) {
+        printf("FAIL: Script missing wait message\n");
+        failures++;
+    }
+    
+    if (strstr(script, "del \"%~f0\"") == NULL) {
+        printf("FAIL: Script missing self-delete\n");
+        failures++;
+    }
+    
+    if (strstr(script, "start \"\"") == NULL) {
+        printf("FAIL: Script missing start command\n");
+        failures++;
+    }
+    
+    // Check the downloaded temp path and final path are different
+    if (strcmp("C:\\Users\\test\\AppData\\Local\\Temp\\nosleep_v2.0.0.exe", 
+               "C:\\Users\\test\\AppData\\Local\\nosleep.exe") == 0) {
+        printf("FAIL: Temp path and final path should differ\n");
+        failures++;
+    }
+    
+    free(script);
+    
+    if (failures == 0) {
+        printf("OK");
+    }
+    return failures;
+}
+EOF
+
+if gcc -o "$TMPDIR/test_update_batch_gen" "$TMPDIR/test_update_batch_gen.c"; then
+    RESULT=$("$TMPDIR/test_update_batch_gen")
+    if [ "$RESULT" = "OK" ]; then
+        pass "Update batch script generation: all checks pass"
+    else
+        fail "Update batch script generation: $RESULT"
+    fi
+else
+    # MingGW might not be available; this is expected on some platforms
+    echo "SKIP: Update batch script generation test (compilation not available)"
+fi
+
+# === Test 3: Registry path generation for notification groups ===
+cat > "$TMPDIR/test_registry_keys.c" << 'EOF'
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define NOTIFY_GROUPS_REG_KEY "Software\\nosleep\\settings\\NotificationGroups"
+#define MAX_GROUP_NAME 128
+#define MAX_GROUPS 20
+#define MAX_NOTIFY_EVENTS 32
+
+// Simulate notification group data structure
+typedef struct {
+    char name[MAX_GROUP_NAME];
+    unsigned int event_mask;  // Bitmask of enabled notification events
+} NotifyGroup;
+
+// Simulate storing groups in registry paths
+// Each group gets a subkey: Software\\nosleep\\settings\\NotificationGroups\\Group_N
+// with "name" and "event_mask" values
+
+int generate_group_reg_path(char* buffer, size_t buf_size, int group_index) {
+    return snprintf(buffer, buf_size, "%s\\Group_%d", NOTIFY_GROUPS_REG_KEY, group_index);
+}
+
+int main() {
+    int failures = 0;
+    
+    char path[512];
+    int len = generate_group_reg_path(path, sizeof(path), 0);
+    
+    if (len <= 0 || (size_t)len >= sizeof(path)) {
+        printf("FAIL: Registry path too long\n");
+        failures++;
+    }
+    
+    const char* expected = "Software\\nosleep\\settings\\NotificationGroups\\Group_0";
+    if (strcmp(path, expected) != 0) {
+        printf("FAIL: Expected '%s', got '%s'\n", expected, path);
+        failures++;
+    }
+    
+    // Test group 5
+    len = generate_group_reg_path(path, sizeof(path), 5);
+    expected = "Software\\nosleep\\settings\\NotificationGroups\\Group_5";
+    if (strcmp(path, expected) != 0) {
+        printf("FAIL: Expected '%s', got '%s'\n", expected, path);
+        failures++;
+    }
+    
+    // Test mask operations
+    unsigned int mask = 0;
+    
+    // Enable event 0
+    mask |= (1 << 0);
+    if (!(mask & (1 << 0))) {
+        printf("FAIL: Event 0 should be enabled\n");
+        failures++;
+    }
+    
+    // Enable event 3
+    mask |= (1 << 3);
+    if (!(mask & (1 << 3))) {
+        printf("FAIL: Event 3 should be enabled\n");
+        failures++;
+    }
+    
+    // Event 1 should still be disabled
+    if (mask & (1 << 1)) {
+        printf("FAIL: Event 1 should be disabled\n");
+        failures++;
+    }
+    
+    // Disable event 0
+    mask &= ~(1 << 0);
+    if (mask & (1 << 0)) {
+        printf("FAIL: Event 0 should now be disabled\n");
+        failures++;
+    }
+    
+    if (failures == 0) {
+        printf("OK");
+    }
+    return failures;
+}
+EOF
+
+if gcc -o "$TMPDIR/test_registry_keys" "$TMPDIR/test_registry_keys.c"; then
+    RESULT=$("$TMPDIR/test_registry_keys")
+    if [ "$RESULT" = "OK" ]; then
+        pass "Registry key generation and bitmask operations: all checks pass"
+    else
+        fail "Registry key generation and bitmask operations: $RESULT"
+    fi
+else
+    echo "SKIP: Registry keys test (compilation not available)"
+fi
+
+# === Summary ===
+echo "---"
+echo "Total: $((PASS+FAIL)) | Pass: $PASS | Fail: $FAIL"
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What this PR does

### Before this PR:
- Settings dialog was a flat single-page dialog with all controls mixed together
- Notification system had only 3 modes (All/Critical/None) with no customization
- Update check only detected new versions but did not download or install
- All code was in a single large tray.c file

### After this PR:
- **Tab-based Settings**: Settings dialog now has two tabs - General and Notifications, making it extensible for future additions
- **Notification Groups**: 3 default groups (All notifications / Critical only / None) preserved, plus ability to add custom groups with custom names
- **Per-event filtering**: Each group can enable/disable individual notification types (10 events) via a popup editor with checkboxes
- **Auto-update download**: When a new version is found, prompts user to download, then creates batch script that replaces EXE (preserving original filename) and restarts the app
- **Modular architecture**: Code split into notify_groups.h/.c and updater.h/.c modules
- **Data migration**: Old notification_mode settings automatically migrated to new group system

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Breaking changes (if any)
None. The old notification_mode registry value is still read for migration purposes.
