### PR TITLE
fix(notify_groups): skip corrupt registry entries instead of stopping enumeration

### DIFF
--- a/src/notify_groups.c
+++ b/src/notify_groups.c
@@ -228,10 +228,10 @@ void notify_groups_load(NotifyGroupManager* mgr) {
         result = RegQueryValueEx(hKeyGroup, "name", NULL, &name_type, (LPBYTE)name, &name_size);
         if (result != ERROR_SUCCESS || name_type != REG_SZ || name[0] == '\0') {
             RegCloseKey(hKeyGroup);
-            break; // Corrupt entry, stop enumeration
+            continue; // Corrupt entry, skip and continue enumeration
         }
-        strncpy(mgr->groups[i].name, name, MAX_GROUP_NAME - 1);
-        mgr->groups[i].name[MAX_GROUP_NAME - 1] = '\0';
+        strncpy(mgr->groups[mgr->count].name, name, MAX_GROUP_NAME - 1);
+        mgr->groups[mgr->count].name[MAX_GROUP_NAME - 1] = '\0';
         
         // Read event mask
         val = 0;
@@ -241,14 +241,14 @@ void notify_groups_load(NotifyGroupManager* mgr) {
         if (result != ERROR_SUCCESS || mask_type != REG_DWORD) {
             val = 0;
         }
-        mgr->groups[i].event_mask = (unsigned int)val;
+        mgr->groups[mgr->count].event_mask = (unsigned int)val;
         
         // Read is_default
         val = 0;
         size = sizeof(DWORD);
         DWORD def_type = 0;
         result = RegQueryValueEx(hKeyGroup, "is_default", NULL, &def_type, (LPBYTE)&val, &size);
-        mgr->groups[i].is_default = (result == ERROR_SUCCESS && def_type == REG_DWORD && val != 0);
+        mgr->groups[mgr->count].is_default = (result == ERROR_SUCCESS && def_type == REG_DWORD && val != 0);
         
         RegCloseKey(hKeyGroup);
         mgr->count++;

--- a/test_notification_groups.sh
+++ b/test_notification_groups.sh
@@ -344,6 +344,240 @@ else
     echo "SKIP: Registry keys test (compilation not available)"
 fi
 
+# === Test 4: Registry group loading - break vs continue behavior for corrupt entries ===
+cat > "$TMPDIR/test_registry_load_continue.c" << 'TESTEOF'
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define MAX_NOTIFY_GROUPS 20
+#define MAX_GROUP_NAME 128
+
+// Simulate OLD behavior: break on corrupt, store at index i (registry subkey index)
+// Returns number of valid groups loaded and fills arr[] at i positions
+int load_groups_break_stored(const char* entries_valid[], int num_entries,
+                              char arr[][MAX_GROUP_NAME]) {
+    int count = 0;
+    for (int i = 0; i < MAX_NOTIFY_GROUPS && i < num_entries; i++) {
+        if (entries_valid[i] == NULL || entries_valid[i][0] == '\0') {
+            break; // Old behavior: stop on corrupt entry
+        }
+        strncpy(arr[i], entries_valid[i], MAX_GROUP_NAME - 1);
+        arr[i][MAX_GROUP_NAME - 1] = '\0';
+        count++;
+    }
+    return count;
+}
+
+// Simulate NEW behavior: continue on corrupt, store at arr[count] (compact)
+// Returns number of valid groups loaded, fills arr[] compactly
+int load_groups_continue_compacted(const char* entries_valid[], int num_entries,
+                                    char arr[][MAX_GROUP_NAME]) {
+    int count = 0;
+    for (int i = 0; i < MAX_NOTIFY_GROUPS && i < num_entries; i++) {
+        if (entries_valid[i] == NULL || entries_valid[i][0] == '\0') {
+            continue; // New behavior: skip corrupt entry
+        }
+        strncpy(arr[count], entries_valid[i], MAX_GROUP_NAME - 1);
+        arr[count][MAX_GROUP_NAME - 1] = '\0';
+        count++;
+    }
+    return count;
+}
+
+// Verify a range of arr[] has NULL (zeroed) entries
+int is_zeroed(const char arr[][MAX_GROUP_NAME], int start, int end) {
+    for (int j = start; j < end; j++) {
+        if (arr[j][0] != '\0') return 0;
+    }
+    return 1;
+}
+
+int main() {
+    int failures = 0;
+    char result_break[MAX_NOTIFY_GROUPS][MAX_GROUP_NAME] = {{0}};
+    char result_cont[MAX_NOTIFY_GROUPS][MAX_GROUP_NAME] = {{0}};
+
+    // ==================================================
+    // Test 1: All entries valid - both produce same result
+    // ==================================================
+    memset(result_break, 0, sizeof(result_break));
+    memset(result_cont, 0, sizeof(result_cont));
+    const char* all_valid[] = {"GroupA", "GroupB", "GroupC"};
+    int r1b = load_groups_break_stored(all_valid, 3, result_break);
+    int r1c = load_groups_continue_compacted(all_valid, 3, result_cont);
+    if (r1b != 3 || r1c != 3) {
+        printf("FAIL Test1a: counts break=%d continue=%d (expected 3)\n", r1b, r1c);
+        failures++;
+    }
+    // Both should have compact arrays
+    if (strcmp(result_break[0], "GroupA") != 0 || strcmp(result_cont[0], "GroupA") != 0) {
+        printf("FAIL Test1b: arr[0] mismatch\n");
+        failures++;
+    }
+    if (strcmp(result_break[1], "GroupB") != 0 || strcmp(result_cont[1], "GroupB") != 0) {
+        printf("FAIL Test1c: arr[1] mismatch\n");
+        failures++;
+    }
+    if (strcmp(result_break[2], "GroupC") != 0 || strcmp(result_cont[2], "GroupC") != 0) {
+        printf("FAIL Test1d: arr[2] mismatch\n");
+        failures++;
+    }
+
+    // ==================================================
+    // Test 2: Corrupt entry in middle
+    // ==================================================
+    memset(result_break, 0, sizeof(result_break));
+    memset(result_cont, 0, sizeof(result_cont));
+    const char* mid_corrupt[] = {"GroupA", NULL, "GroupC"};
+    int r2b = load_groups_break_stored(mid_corrupt, 3, result_break);
+    int r2c = load_groups_continue_compacted(mid_corrupt, 3, result_cont);
+    // break: stops at index 1, only GroupA loaded
+    if (r2b != 1) {
+        printf("FAIL Test2a: break count=%d (expected 1)\n", r2b);
+        failures++;
+    }
+    if (strcmp(result_break[0], "GroupA") != 0) {
+        printf("FAIL Test2b: break arr[0]=%s (expected GroupA)\n", result_break[0]);
+        failures++;
+    }
+    // verify break did NOT touch arr[1] and arr[2]
+    if (!is_zeroed(result_break, 1, 3)) {
+        printf("FAIL Test2c: break left data beyond arr[0], possible gap\n");
+        failures++;
+    }
+    // continue: skips NULL, loads GroupA at [0], GroupC at [1] (compact!)
+    if (r2c != 2) {
+        printf("FAIL Test2d: continue count=%d (expected 2)\n", r2c);
+        failures++;
+    }
+    if (strcmp(result_cont[0], "GroupA") != 0) {
+        printf("FAIL Test2e: continue arr[0]=%s (expected GroupA)\n", result_cont[0]);
+        failures++;
+    }
+    if (strcmp(result_cont[1], "GroupC") != 0) {
+        printf("FAIL Test2f: continue arr[1]=%s (expected GroupC)\n", result_cont[1]);
+        failures++;
+    }
+    // arr[1..MAX] must be zeroed (compact array, no gaps)
+    if (!is_zeroed(result_cont, 2, MAX_NOTIFY_GROUPS)) {
+        printf("FAIL Test2g: continue array has unexpected data after count\n");
+        failures++;
+    }
+
+    // ==================================================
+    // Test 3: First entry corrupt
+    // ==================================================
+    memset(result_break, 0, sizeof(result_break));
+    memset(result_cont, 0, sizeof(result_cont));
+    const char* first_corrupt[] = {NULL, "GroupB", "GroupC"};
+    int r3b = load_groups_break_stored(first_corrupt, 3, result_break);
+    int r3c = load_groups_continue_compacted(first_corrupt, 3, result_cont);
+    if (r3b != 0) {
+        printf("FAIL Test3a: break count=%d (expected 0)\n", r3b);
+        failures++;
+    }
+    if (r3c != 2) {
+        printf("FAIL Test3c: continue count=%d (expected 2)\n", r3c);
+        failures++;
+    }
+    if (strcmp(result_cont[0], "GroupB") != 0 || strcmp(result_cont[1], "GroupC") != 0) {
+        printf("FAIL Test3d: continue compact storage wrong\n");
+        failures++;
+    }
+    if (!is_zeroed(result_cont, 2, MAX_NOTIFY_GROUPS)) {
+        printf("FAIL Test3e: continue array has unexpected data after count\n");
+        failures++;
+    }
+
+    // ==================================================
+    // Test 4: Last entry corrupt
+    // ==================================================
+    memset(result_break, 0, sizeof(result_break));
+    memset(result_cont, 0, sizeof(result_cont));
+    const char* last_corrupt[] = {"GroupA", "GroupB", NULL};
+    int r4b = load_groups_break_stored(last_corrupt, 3, result_break);
+    int r4c = load_groups_continue_compacted(last_corrupt, 3, result_cont);
+    if (r4b != 2 || r4c != 2) {
+        printf("FAIL Test4a: counts break=%d continue=%d (expected 2)\n", r4b, r4c);
+        failures++;
+    }
+    if (strcmp(result_break[0], "GroupA") != 0 || strcmp(result_cont[0], "GroupA") != 0) {
+        printf("FAIL Test4b: arr[0] mismatch\n");
+        failures++;
+    }
+    if (strcmp(result_break[1], "GroupB") != 0 || strcmp(result_cont[1], "GroupB") != 0) {
+        printf("FAIL Test4c: arr[1] mismatch\n");
+        failures++;
+    }
+
+    // ==================================================
+    // Test 5: Multiple corrupt entries interleaved
+    // ==================================================
+    memset(result_break, 0, sizeof(result_break));
+    memset(result_cont, 0, sizeof(result_cont));
+    const char* multi_corrupt[] = {"GroupA", NULL, "GroupC", NULL, "GroupE"};
+    int r5b = load_groups_break_stored(multi_corrupt, 5, result_break);
+    int r5c = load_groups_continue_compacted(multi_corrupt, 5, result_cont);
+    if (r5b != 1) {
+        printf("FAIL Test5a: break count=%d (expected 1)\n", r5b);
+        failures++;
+    }
+    if (r5c != 3) {
+        printf("FAIL Test5c: continue count=%d (expected 3)\n", r5c);
+        failures++;
+    }
+    // continue must store compactly: [0]=A, [1]=C, [2]=E
+    if (strcmp(result_cont[0], "GroupA") != 0 ||
+        strcmp(result_cont[1], "GroupC") != 0 ||
+        strcmp(result_cont[2], "GroupE") != 0) {
+        printf("FAIL Test5d: continue compact storage wrong\n");
+        failures++;
+    }
+    if (!is_zeroed(result_cont, 3, MAX_NOTIFY_GROUPS)) {
+        printf("FAIL Test5e: continue array has unexpected data after count\n");
+        failures++;
+    }
+
+    // ==================================================
+    // Test 6: Empty string entry (name[0] == '\0' case)
+    // ==================================================
+    memset(result_break, 0, sizeof(result_break));
+    memset(result_cont, 0, sizeof(result_cont));
+    const char* empty_name[] = {"GroupA", "", "GroupC"};
+    int r6b = load_groups_break_stored(empty_name, 3, result_break);
+    int r6c = load_groups_continue_compacted(empty_name, 3, result_cont);
+    if (r6b != 1) {
+        printf("FAIL Test6a: break count=%d (expected 1)\n", r6b);
+        failures++;
+    }
+    if (r6c != 2) {
+        printf("FAIL Test6c: continue count=%d (expected 2)\n", r6c);
+        failures++;
+    }
+    if (strcmp(result_cont[0], "GroupA") != 0 || strcmp(result_cont[1], "GroupC") != 0) {
+        printf("FAIL Test6d: continue compact storage wrong\n");
+        failures++;
+    }
+
+    if (failures == 0) {
+        printf("OK");
+    }
+    return failures;
+}
+TESTEOF
+
+if gcc -o "$TMPDIR/test_registry_load_continue.exe" "$TMPDIR/test_registry_load_continue.c"; then
+    RESULT=$("$TMPDIR/test_registry_load_continue.exe")
+    if [ "$RESULT" = "OK" ]; then
+        pass "Registry load continue: all 6 cases correct (break stops, continue skips + compact)"
+    else
+        fail "Registry load continue: $RESULT"
+    fi
+else
+    echo "SKIP: Registry load continue test (compilation not available)"
+fi
+
 # === Summary ===
 echo "---"
 echo "Total: $((PASS+FAIL)) | Pass: $PASS | Fail: $FAIL"


### PR DESCRIPTION
## What this PR does

Change \
otify_groups_load\ to use \continue\ instead of \reak\ when a corrupt registry entry is encountered, so subsequent valid groups can still be loaded.

### Before this PR:
When loading notification groups from the registry, encountering a corrupt entry (e.g., missing name value, wrong type, or empty name) would cause \reak\, stopping all further enumeration. Any valid groups stored after the corrupt entry were permanently lost.

### After this PR:
Corrupt entries are skipped with \continue\, allowing valid groups after the corruption to still be loaded. Additionally, the storage index was changed from the loop variable \i\ (registry subkey index) to \mgr->count\ (valid group counter) to keep the \groups[]\ array compact and gap-free.

### Changes:
1. **\src/notify_groups.c\** — In \
otify_groups_load\:
   - Changed \reak\ to \continue\ when a corrupt entry is detected (line 231)
   - Changed \mgr->groups[i]\ to \mgr->groups[mgr->count]\ for name, event_mask, and is_default writes (lines 233, 234, 244, 251) to keep array compact
2. **\	est_notification_groups.sh\** — Added Test 4 that simulates both old (break) and new (continue+compact) behaviors across 6 scenarios

### Type of change
fix

### Breaking changes (if any)
None