### PR TITLE
refactor(cli): extract parse_arguments output into CLIOptions struct

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -16,41 +16,84 @@
 #define CLI_DISABLE 0
 #define CLI_ENABLE 1
 
+// Structure holding all parsed CLI options (reduces parameter count for parse_arguments)
+typedef struct {
+    // Run options
+    int duration;              // -1 = not set (tray mode default), 0 = indefinite
+    int interval;              // seconds
+    bool prevent_display;
+    bool away_mode;
+    bool verbose;
+    bool tray_mode;
+    bool startup;
+
+    // Track whether legacy CLI flags were explicitly specified
+    bool prevent_display_set;
+    bool away_mode_set;
+    bool verbose_set;
+
+    // Batch mode settings (-1 = not specified)
+    int session_finished;
+    int auto_start;
+    int notification_mode;
+    int auto_check_interval;
+    int check_updates_startup;
+    int add_to_path;
+    bool configure_mode;
+    bool show_version;
+} CLIOptions;
+
+// Help text shown by --help (static global to avoid stack allocation on each invocation)
+static const char* const HELP_TEXT =
+    "nosleep - Prevent Windows from sleeping using SetThreadExecutionState API\n\n"
+    "Usage: nosleep [OPTIONS]\n\n"
+    "Run Options (start nosleep with these settings):\n"
+    "  -d, --duration MINUTES    Duration in minutes to prevent sleep\n"
+    "                            (positive integer, 0 or negative = indefinite)\n"
+    "  -i, --interval SECONDS    Interval in seconds to refresh sleep prevention\n"
+    "                            (default: 20)\n"
+    "  -p, --prevent-display     Also prevent display from sleeping\n"
+    "  -a, --away-mode           Enable away mode (requires compatible hardware)\n"
+    "  -v, --verbose             Print detailed status to debug output\n"
+    "  -t, --tray                Start in system tray mode\n"
+    "                            (default if no arguments provided)\n"
+    "  -s, --startup             Start sleep prevention immediately (for Windows startup)\n"
+    "\n"
+    "Configure Options (persistent settings, saved to registry):\n"
+    "  --session-finished MODE   Action after timer expires\n"
+    "                            (none, shutdown, sleep)\n"
+    "  --notification-mode MODE  Notification mode\n"
+    "                            (all, critical, none)\n"
+    "  --auto-check-interval I   Update check interval\n"
+    "                            (never, daily, weekly)\n"
+    "  --auto-start              Enable auto-start with Windows\n"
+    "  --no-auto-start           Disable auto-start with Windows\n"
+    "  --check-updates-startup   Enable check for updates on startup\n"
+    "  --no-check-updates-startup Disable check for updates on startup\n"
+    "  --add-to-path             Add nosleep directory to environment PATH\n"
+    "  --no-add-to-path          Remove nosleep directory from environment PATH\n"
+    "  --configure               Save settings to registry and exit\n"
+    "                            (use with above options to persist them)\n"
+    "\n"
+    "Information:\n"
+    "  --version, -V             Show version information\n"
+    "  -h, --help                Show this help message\n"
+    "\n"
+    "Examples:\n"
+    "  nosleep --duration 30 --prevent-display\n"
+    "  nosleep -d 60 -i 10 -v\n"
+    "  nosleep --tray\n"
+    "  nosleep --session-finished shutdown --configure\n"
+    "  nosleep --auto-start --notification-mode critical --configure\n"
+    "  nosleep --add-to-path --configure\n"
+    "  nosleep --version\n"
+    "  nosleep                     (starts tray mode)\n";
+
 // Function prototypes
 
-static int parse_arguments(int argc, wchar_t* argv[], 
-                          int* duration, int* interval,
-                          bool* prevent_display, bool* away_mode,
-                          bool* verbose, bool* tray_mode,
-                          bool* startup,
-                          int* session_finished,
-                          int* auto_start,
-                          int* notification_mode,
-                          int* auto_check_interval,
-                          int* check_updates_startup,
-                          int* add_to_path,
-                          bool* configure_mode,
-                          bool* show_version,
-                          bool* prevent_display_set,
-                          bool* away_mode_set,
-                          bool* verbose_set);
-static int run_tray_mode(bool prevent_display, bool away_mode, bool verbose,
-                         int duration_minutes,
-                         int session_finished,
-                         int auto_start,
-                         int notification_mode,
-                         int auto_check_interval,
-                         int check_updates_startup,
-                         int add_to_path,
-                         bool prevent_display_set,
-                         bool away_mode_set,
-                         bool verbose_set);
-static int run_configure_mode(int session_finished,
-                              int auto_start,
-                              int notification_mode,
-                              int auto_check_interval,
-                              int check_updates_startup,
-                              int add_to_path);
+static int parse_arguments(int argc, wchar_t* argv[], CLIOptions* opts);
+static int run_tray_mode(const CLIOptions* opts);
+static int run_configure_mode(const CLIOptions* opts);
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
     // Enable DPI awareness for proper font rendering on high-DPI displays
@@ -62,29 +105,27 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     (void)lpCmdLine;
     (void)nCmdShow;
     
-    // Default values
-    int duration = -1;         // -1 = not set (tray mode default), 0 = indefinite
-    int interval = 20;         // seconds
-    bool prevent_display = false;
-    bool away_mode = false;
-    bool verbose = false;
-    bool tray_mode = false;
-    bool startup = false;
-    
-    // Track whether legacy CLI flags were explicitly specified
-    bool prevent_display_set = false;
-    bool away_mode_set = false;
-    bool verbose_set = false;
-    
-    // New batch mode settings (-1 = not specified)
-    int session_finished = CLI_UNSET;
-    int auto_start = CLI_UNSET;
-    int notification_mode = CLI_UNSET;
-    int auto_check_interval = CLI_UNSET;
-    int check_updates_startup = CLI_UNSET;
-    int add_to_path = CLI_UNSET;
-    bool configure_mode = false;
-    bool show_version = false;
+    // Default values in CLIOptions struct
+    CLIOptions opts = {
+        .duration = -1,              // -1 = not set (tray mode default), 0 = indefinite
+        .interval = 20,              // seconds
+        .prevent_display = false,
+        .away_mode = false,
+        .verbose = false,
+        .tray_mode = false,
+        .startup = false,
+        .prevent_display_set = false,
+        .away_mode_set = false,
+        .verbose_set = false,
+        .session_finished = CLI_UNSET,
+        .auto_start = CLI_UNSET,
+        .notification_mode = CLI_UNSET,
+        .auto_check_interval = CLI_UNSET,
+        .check_updates_startup = CLI_UNSET,
+        .add_to_path = CLI_UNSET,
+        .configure_mode = false,
+        .show_version = false
+    };
     
     // Parse command line arguments using Windows API
     int argc = 0;
@@ -92,29 +133,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     
     if (!argv) {
         // Could not parse command line, default to tray mode
-        return run_tray_mode(prevent_display, away_mode, verbose, duration,
-                            session_finished, auto_start,
-                            notification_mode, auto_check_interval,
-                            check_updates_startup,
-                            add_to_path,
-                            prevent_display_set, away_mode_set, verbose_set);
+        return run_tray_mode(&opts);
     }
     
     // Parse arguments
-    int parse_result = parse_arguments(argc, argv, &duration, &interval,
-                                       &prevent_display, &away_mode,
-                                       &verbose, &tray_mode, &startup,
-                                       &session_finished,
-                                       &auto_start,
-                                       &notification_mode,
-                                       &auto_check_interval,
-                                       &check_updates_startup,
-                                       &add_to_path,
-                                       &configure_mode,
-                                       &show_version,
-                                       &prevent_display_set,
-                                       &away_mode_set,
-                                       &verbose_set);
+    int parse_result = parse_arguments(argc, argv, &opts);
     
     LocalFree(argv);
     
@@ -132,62 +155,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             freopen("CONOUT$", "w", stdout);
             freopen("CONOUT$", "w", stderr);
         }
-        const char* help_text = 
-            "nosleep - Prevent Windows from sleeping using SetThreadExecutionState API\n\n"
-            "Usage: nosleep [OPTIONS]\n\n"
-            "Run Options (start nosleep with these settings):\n"
-            "  -d, --duration MINUTES    Duration in minutes to prevent sleep\n"
-            "                            (positive integer, 0 or negative = indefinite)\n"
-            "  -i, --interval SECONDS    Interval in seconds to refresh sleep prevention\n"
-            "                            (default: 20)\n"
-            "  -p, --prevent-display     Also prevent display from sleeping\n"
-            "  -a, --away-mode           Enable away mode (requires compatible hardware)\n"
-            "  -v, --verbose             Print detailed status to debug output\n"
-            "  -t, --tray                Start in system tray mode\n"
-            "                            (default if no arguments provided)\n"
-            "  -s, --startup             Start sleep prevention immediately (for Windows startup)\n"
-            "\n"
-            "Configure Options (persistent settings, saved to registry):\n"
-            "  --session-finished MODE   Action after timer expires\n"
-            "                            (none, shutdown, sleep)\n"
-            "  --notification-mode MODE  Notification mode\n"
-            "                            (all, critical, none)\n"
-            "  --auto-check-interval I   Update check interval\n"
-            "                            (never, daily, weekly)\n"
-            "  --auto-start              Enable auto-start with Windows\n"
-            "  --no-auto-start           Disable auto-start with Windows\n"
-            "  --check-updates-startup   Enable check for updates on startup\n"
-            "  --no-check-updates-startup Disable check for updates on startup\n"
-            "  --add-to-path             Add nosleep directory to environment PATH\n"
-            "  --no-add-to-path          Remove nosleep directory from environment PATH\n"
-            "  --configure               Save settings to registry and exit\n"
-            "                            (use with above options to persist them)\n"
-            "\n"
-            "Information:\n"
-            "  --version, -V             Show version information\n"
-            "  -h, --help                Show this help message\n"
-            "\n"
-            "Examples:\n"
-            "  nosleep --duration 30 --prevent-display\n"
-            "  nosleep -d 60 -i 10 -v\n"
-            "  nosleep --tray\n"
-            "  nosleep --session-finished shutdown --configure\n"
-            "  nosleep --auto-start --notification-mode critical --configure\n"
-            "  nosleep --add-to-path --configure\n"
-            "  nosleep --version\n"
-            "  nosleep                     (starts tray mode)\n";
-        
-        printf("%s", help_text);
+        printf("%s", HELP_TEXT);
         return 0;
     }
     
     // If --startup was passed and no explicit duration, auto-start indefinitely
-    if (startup && duration < 0) {
-        duration = 0;
+    if (opts.startup && opts.duration < 0) {
+        opts.duration = 0;
     }
     
     // --version mode: show version and exit
-    if (show_version) {
+    if (opts.show_version) {
         if (AttachConsole(ATTACH_PARENT_PROCESS)) {
             freopen("CONOUT$", "w", stdout);
             freopen("CONOUT$", "w", stderr);
@@ -197,11 +175,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     }
     
     // --configure mode: save settings to registry and exit
-    if (configure_mode) {
+    if (opts.configure_mode) {
         // Check if any settings were actually provided
-        if (session_finished == CLI_UNSET && auto_start == CLI_UNSET &&
-            notification_mode == CLI_UNSET && auto_check_interval == CLI_UNSET &&
-            check_updates_startup == CLI_UNSET && add_to_path == CLI_UNSET) {
+        if (opts.session_finished == CLI_UNSET && opts.auto_start == CLI_UNSET &&
+            opts.notification_mode == CLI_UNSET && opts.auto_check_interval == CLI_UNSET &&
+            opts.check_updates_startup == CLI_UNSET && opts.add_to_path == CLI_UNSET) {
             if (AttachConsole(ATTACH_PARENT_PROCESS)) {
                 freopen("CONOUT$", "w", stdout);
                 freopen("CONOUT$", "w", stderr);
@@ -209,38 +187,16 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             fprintf(stderr, "nosleep: No settings provided with --configure. Use --help for usage.\n");
             return 1;
         }
-        return run_configure_mode(session_finished, auto_start,
-                                  notification_mode, auto_check_interval,
-                                  check_updates_startup, add_to_path);
+        return run_configure_mode(&opts);
     }
     
     // Default: run tray mode with CLI overrides
-    return run_tray_mode(prevent_display, away_mode, verbose, duration,
-                         session_finished, auto_start,
-                         notification_mode, auto_check_interval,
-                         check_updates_startup,
-                         add_to_path,
-                         prevent_display_set, away_mode_set, verbose_set);
+    return run_tray_mode(&opts);
 }
 
 
 
-static int parse_arguments(int argc, wchar_t* argv[], 
-                          int* duration, int* interval,
-                          bool* prevent_display, bool* away_mode,
-                          bool* verbose, bool* tray_mode,
-                          bool* startup,
-                          int* session_finished,
-                          int* auto_start,
-                          int* notification_mode,
-                          int* auto_check_interval,
-                          int* check_updates_startup,
-                          int* add_to_path,
-                          bool* configure_mode,
-                          bool* show_version,
-                          bool* prevent_display_set,
-                          bool* away_mode_set,
-                          bool* verbose_set) {
+static int parse_arguments(int argc, wchar_t* argv[], CLIOptions* opts) {
     for (int i = 1; i < argc; i++) {
         // Convert wide char to UTF-8 for comparison
         char arg[256];
@@ -250,52 +206,52 @@ static int parse_arguments(int argc, wchar_t* argv[],
             return 2;
         }
         else if (strcmp(arg, "--version") == 0 || strcmp(arg, "-V") == 0) {
-            *show_version = true;
+            opts->show_version = true;
         }
         else if (strcmp(arg, "--duration") == 0 || strcmp(arg, "-d") == 0) {
             if (i + 1 >= argc) return 1;
             char value[256];
             WideCharToMultiByte(CP_UTF8, 0, argv[++i], -1, value, sizeof(value), NULL, NULL);
-            *duration = atoi(value);
+            opts->duration = atoi(value);
         }
         else if (strcmp(arg, "--interval") == 0 || strcmp(arg, "-i") == 0) {
             if (i + 1 >= argc) return 1;
             char value[256];
             WideCharToMultiByte(CP_UTF8, 0, argv[++i], -1, value, sizeof(value), NULL, NULL);
-            *interval = atoi(value);
-            if (*interval <= 0) return 1;
+            opts->interval = atoi(value);
+            if (opts->interval <= 0) return 1;
         }
         else if (strcmp(arg, "--prevent-display") == 0 || strcmp(arg, "-p") == 0) {
-            *prevent_display = true;
-            *prevent_display_set = true;
+            opts->prevent_display = true;
+            opts->prevent_display_set = true;
         }
         else if (strcmp(arg, "--away-mode") == 0 || strcmp(arg, "-a") == 0) {
-            *away_mode = true;
-            *away_mode_set = true;
+            opts->away_mode = true;
+            opts->away_mode_set = true;
         }
         else if (strcmp(arg, "--verbose") == 0 || strcmp(arg, "-v") == 0) {
-            *verbose = true;
-            *verbose_set = true;
+            opts->verbose = true;
+            opts->verbose_set = true;
         }
         else if (strcmp(arg, "--tray") == 0 || strcmp(arg, "-t") == 0) {
-            *tray_mode = true;
+            opts->tray_mode = true;
         }
         else if (strcmp(arg, "--startup") == 0 || strcmp(arg, "-s") == 0) {
-            *startup = true;
+            opts->startup = true;
         }
         else if (strcmp(arg, "--configure") == 0) {
-            *configure_mode = true;
+            opts->configure_mode = true;
         }
         else if (strcmp(arg, "--session-finished") == 0) {
             if (i + 1 >= argc) return 1;
             char value[256];
             WideCharToMultiByte(CP_UTF8, 0, argv[++i], -1, value, sizeof(value), NULL, NULL);
             if (strcmp(value, "none") == 0) {
-                *session_finished = SESSION_FINISHED_NONE;
+                opts->session_finished = SESSION_FINISHED_NONE;
             } else if (strcmp(value, "shutdown") == 0) {
-                *session_finished = SESSION_FINISHED_SHUTDOWN;
+                opts->session_finished = SESSION_FINISHED_SHUTDOWN;
             } else if (strcmp(value, "sleep") == 0) {
-                *session_finished = SESSION_FINISHED_SLEEP;
+                opts->session_finished = SESSION_FINISHED_SLEEP;
             } else {
                 return 1;
             }
@@ -305,11 +261,11 @@ static int parse_arguments(int argc, wchar_t* argv[],
             char value[256];
             WideCharToMultiByte(CP_UTF8, 0, argv[++i], -1, value, sizeof(value), NULL, NULL);
             if (strcmp(value, "all") == 0) {
-                *notification_mode = NOTIFY_ALL;
+                opts->notification_mode = NOTIFY_ALL;
             } else if (strcmp(value, "critical") == 0) {
-                *notification_mode = NOTIFY_CRITICAL_ONLY;
+                opts->notification_mode = NOTIFY_CRITICAL_ONLY;
             } else if (strcmp(value, "none") == 0) {
-                *notification_mode = NOTIFY_NONE;
+                opts->notification_mode = NOTIFY_NONE;
             } else {
                 return 1;
             }
@@ -319,32 +275,32 @@ static int parse_arguments(int argc, wchar_t* argv[],
             char value[256];
             WideCharToMultiByte(CP_UTF8, 0, argv[++i], -1, value, sizeof(value), NULL, NULL);
             if (strcmp(value, "never") == 0) {
-                *auto_check_interval = 0;
+                opts->auto_check_interval = 0;
             } else if (strcmp(value, "daily") == 0) {
-                *auto_check_interval = 1;
+                opts->auto_check_interval = 1;
             } else if (strcmp(value, "weekly") == 0) {
-                *auto_check_interval = 2;
+                opts->auto_check_interval = 2;
             } else {
                 return 1;
             }
         }
         else if (strcmp(arg, "--auto-start") == 0) {
-            *auto_start = CLI_ENABLE;
+            opts->auto_start = CLI_ENABLE;
         }
         else if (strcmp(arg, "--no-auto-start") == 0) {
-            *auto_start = CLI_DISABLE;
+            opts->auto_start = CLI_DISABLE;
         }
         else if (strcmp(arg, "--check-updates-startup") == 0) {
-            *check_updates_startup = CLI_ENABLE;
+            opts->check_updates_startup = CLI_ENABLE;
         }
         else if (strcmp(arg, "--no-check-updates-startup") == 0) {
-            *check_updates_startup = CLI_DISABLE;
+            opts->check_updates_startup = CLI_DISABLE;
         }
         else if (strcmp(arg, "--add-to-path") == 0) {
-            *add_to_path = CLI_ENABLE;
+            opts->add_to_path = CLI_ENABLE;
         }
         else if (strcmp(arg, "--no-add-to-path") == 0) {
-            *add_to_path = CLI_DISABLE;
+            opts->add_to_path = CLI_DISABLE;
         }
         else {
             return 1; // Unknown argument
@@ -356,21 +312,16 @@ static int parse_arguments(int argc, wchar_t* argv[],
 
 
 
-static int run_configure_mode(int session_finished,
-                              int auto_start,
-                              int notification_mode,
-                              int auto_check_interval,
-                              int check_updates_startup,
-                              int add_to_path) {
+static int run_configure_mode(const CLIOptions* opts) {
     // Attach to parent console for status output
     if (AttachConsole(ATTACH_PARENT_PROCESS)) {
         freopen("CONOUT$", "w", stdout);
         freopen("CONOUT$", "w", stderr);
     }
     
-    bool success = tray_save_settings_cli(session_finished, auto_start,
-                           notification_mode, auto_check_interval,
-                           check_updates_startup, add_to_path);
+    bool success = tray_save_settings_cli(opts->session_finished, opts->auto_start,
+                           opts->notification_mode, opts->auto_check_interval,
+                           opts->check_updates_startup, opts->add_to_path);
     
     if (success) {
         printf("nosleep: Settings saved to registry.\n");
@@ -383,17 +334,7 @@ static int run_configure_mode(int session_finished,
 
 
 
-static int run_tray_mode(bool prevent_display, bool away_mode, bool verbose,
-                         int duration_minutes,
-                         int session_finished,
-                         int auto_start,
-                         int notification_mode,
-                         int auto_check_interval,
-                         int check_updates_startup,
-                         int add_to_path,
-                         bool prevent_display_set,
-                         bool away_mode_set,
-                         bool verbose_set) {
+static int run_tray_mode(const CLIOptions* opts) {
     const char* debug = getenv("NOSLEEP_DEBUG");
     if (debug && strcmp(debug, "1") == 0) {
         OutputDebugString("[nosleep] run_tray_mode: starting with debug enabled\n");
@@ -417,38 +358,38 @@ static int run_tray_mode(bool prevent_display, bool away_mode, bool verbose,
     // so that command-line flags take precedence over registry defaults.
     // Only override legacy bool fields if the user explicitly specified them,
     // preserving registry-loaded values when no flag is passed.
-    if (prevent_display_set) {
-        tray->prevent_display = prevent_display;
+    if (opts->prevent_display_set) {
+        tray->prevent_display = opts->prevent_display;
     }
-    if (away_mode_set) {
-        tray->away_mode = away_mode;
+    if (opts->away_mode_set) {
+        tray->away_mode = opts->away_mode;
     }
-    if (verbose_set) {
-        tray->verbose = verbose;
+    if (opts->verbose_set) {
+        tray->verbose = opts->verbose;
     }
     
-    if (session_finished >= 0) {
-        tray->session_finished_action = (SessionFinishedAction)session_finished;
+    if (opts->session_finished >= 0) {
+        tray->session_finished_action = (SessionFinishedAction)opts->session_finished;
     }
-    if (auto_start >= 0) {
-        tray_set_startup_enabled(tray, auto_start != 0);
+    if (opts->auto_start >= 0) {
+        tray_set_startup_enabled(tray, opts->auto_start != 0);
     }
-    if (notification_mode >= 0) {
-        tray->notification_mode = notification_mode;
+    if (opts->notification_mode >= 0) {
+        tray->notification_mode = opts->notification_mode;
     }
-    if (auto_check_interval >= 0) {
-        tray->auto_check_interval = auto_check_interval;
+    if (opts->auto_check_interval >= 0) {
+        tray->auto_check_interval = opts->auto_check_interval;
     }
-    if (check_updates_startup >= 0) {
-        tray->check_updates_on_startup = (check_updates_startup != 0);
+    if (opts->check_updates_startup >= 0) {
+        tray->check_updates_on_startup = (opts->check_updates_startup != 0);
     }
-    if (add_to_path >= 0) {
-        tray_set_add_to_path(tray, add_to_path != 0);
+    if (opts->add_to_path >= 0) {
+        tray_set_add_to_path(tray, opts->add_to_path != 0);
     }
     
     // If duration is specified, auto-start (0 = indefinite, >0 = minutes)
-    if (duration_minutes >= 0) {
-        tray_start_nosleep(tray, duration_minutes);
+    if (opts->duration >= 0) {
+        tray_start_nosleep(tray, opts->duration);
     }
     
     tray_run(tray);

--- a/test_cli_batch_mode.sh
+++ b/test_cli_batch_mode.sh
@@ -20,7 +20,7 @@ trap "rm -rf $TMPDIR" EXIT
 echo "=== Test: --help output includes new flags ==="
 
 # Extract help text from main.c
-HELP_TEXT=$(sed -n '/const char\* help_text/,/^;/p' src/main.c | tr -d '\n' | sed 's/const char\* help_text = //' | sed 's/;$//' | sed 's/"//g')
+HELP_TEXT=$(sed -n '/HELP_TEXT/,/^;/p' src/main.c | tr -d '\n' | sed 's/static const char\* const HELP_TEXT = //' | sed 's/;$//' | sed 's/"//g')
 
 check_help_flag() {
     local flag="$1"

--- a/test_cli_options_refactor.sh
+++ b/test_cli_options_refactor.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Test: CLI options struct refactoring
+# Validates that:
+# 1. CLIOptions struct is defined in main.c
+# 2. parse_arguments uses CLIOptions* instead of 18 parameters
+# 3. run_tray_mode uses const CLIOptions*
+# 4. run_configure_mode uses const CLIOptions*
+# 5. help_text is a static const global constant
+# 6. Project compiles successfully
+
+set -euo pipefail
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+
+# Create a temp dir for compilation tests
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+echo "=== Test 1: CLIOptions struct is defined ==="
+
+if grep -q "} CLIOptions" src/main.c; then
+    pass "CLIOptions struct typedef found with closing brace"
+    
+    # Verify it has the expected fields inside the struct definition
+    STRUCT_BODY=$(sed -n '/^typedef struct {/,/^} CLIOptions/p' src/main.c)
+    for field in duration interval prevent_display away_mode verbose tray_mode startup \
+                 prevent_display_set away_mode_set verbose_set \
+                 session_finished auto_start notification_mode auto_check_interval \
+                 check_updates_startup add_to_path configure_mode show_version; do
+        if echo "$STRUCT_BODY" | grep -q "$field"; then
+            pass "  CLIOptions field '$field' found"
+        fi
+    done
+else
+    fail "CLIOptions struct not found in main.c"
+fi
+
+echo ""
+echo "=== Test 2: parse_arguments uses CLIOptions* ==="
+
+if grep -q "parse_arguments.*CLIOptions" src/main.c; then
+    pass "parse_arguments references CLIOptions"
+else
+    fail "parse_arguments does not reference CLIOptions"
+fi
+
+if grep -q "parse_arguments(int argc, wchar_t\* argv\[\], CLIOptions" src/main.c; then
+    pass "parse_arguments signature uses CLIOptions*"
+else
+    fail "parse_arguments signature does not use CLIOptions*"
+fi
+
+echo ""
+echo "=== Test 3: run_tray_mode uses const CLIOptions* ==="
+
+if grep -q "run_tray_mode.*const.*CLIOptions" src/main.c; then
+    pass "run_tray_mode uses const CLIOptions*"
+else
+    fail "run_tray_mode does not use const CLIOptions*"
+fi
+
+echo ""
+echo "=== Test 4: run_configure_mode uses const CLIOptions* ==="
+
+if grep -q "run_configure_mode.*const.*CLIOptions" src/main.c; then
+    pass "run_configure_mode uses const CLIOptions*"
+else
+    fail "run_configure_mode does not use const CLIOptions*"
+fi
+
+echo ""
+echo "=== Test 5: help_text is static const global ==="
+
+# Multiple patterns to detect the static const global
+if grep -q "^static const char\* const HELP_TEXT" src/main.c || \
+   grep -q "^static const char \*const HELP_TEXT" src/main.c; then
+    pass "HELP_TEXT is static const global constant"
+elif grep -q "^static const char" src/main.c; then
+    pass "Found static const char declaration (for HELP_TEXT)"
+else
+    # Check it's not a local in WinMain anymore
+    if grep -q "const char\* help_text" src/main.c; then
+        fail "help_text still appears as local variable (not static const)"
+    else
+        pass "No local const char* help_text found (should be global now)"
+    fi
+fi
+
+echo ""
+echo "=== Test 6: Project compiles cleanly ==="
+
+MAKE=mingw32-make
+if $MAKE clean 2>/dev/null && $MAKE 2>/dev/null; then
+    pass "Project compiles successfully with the refactored code"
+    
+    echo ""
+    echo "=== Test 7: --help flag runs without crash ==="
+    # GUI app - output may not capture in all contexts, check at least it doesn't hang/crash
+    if timeout 5 ./bin/nosleep.exe --help > /dev/null 2>&1; then
+        pass "--help command runs and exits cleanly"
+    else
+        # Try without timeout
+        if ./bin/nosleep.exe --help > /dev/null 2>&1; then
+            pass "--help command runs and exits cleanly"
+        else
+            fail "--help command had non-zero exit"
+        fi
+    fi
+    
+    echo ""
+    echo "=== Test 8: --version flag runs without crash ==="
+    if timeout 5 ./bin/nosleep.exe --version > /dev/null 2>&1; then
+        pass "--version command runs and exits cleanly"
+    else
+        if ./bin/nosleep.exe --version > /dev/null 2>&1; then
+            pass "--version command runs and exits cleanly"
+        else
+            fail "--version command had non-zero exit"
+        fi
+    fi
+    
+    echo ""
+    echo "=== Test 9: Invalid args produce non-zero exit ==="
+    if timeout 5 ./bin/nosleep.exe --invalid-flag > /dev/null 2>&1; then
+        fail "Invalid args did not produce non-zero exit"
+    else
+        INVALID_EXIT=$?
+        if [ $INVALID_EXIT -ne 0 ]; then
+            pass "Invalid args produce non-zero exit (exit code: $INVALID_EXIT)"
+        else
+            fail "Invalid args produced zero exit"
+        fi
+    fi
+else
+    fail "Project compilation FAILED"
+    echo "  (Check compiler output above for details)"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "========"
+echo "Total: $((PASS+FAIL)) | Pass: $PASS | Fail: $FAIL"
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What this PR does

### Before this PR:
- \parse_arguments\ had 18 individual output parameters, making it hard to read and maintain
- Help text was a local \const char*\ variable on the stack, reallocated each \--help\ invocation
- \un_tray_mode\ (12 params) and \un_configure_mode\ (6 params) also suffered from parameter explosion

### After this PR:
- All output parameters are collected into a \struct CLIOptions\ with clear field names and documentation
- \parse_arguments\ now takes \(int argc, wchar_t* argv[], CLIOptions* opts)\ — down from 20 params to 3
- \un_tray_mode\ and \un_configure_mode\ accept \const CLIOptions*\ — no more unpacking at call sites
- Help text is now a \static const char* const\ global constant, allocated at compile time
- Added \	est_cli_options_refactor.sh\ to verify the refactoring

Fixes Item 4 and Item 10 from the code review

### Type of change
Refactor

### Breaking changes (if any)
None — all changed functions are \static\ to \main.c\, no public API affected