### PR TITLE
fix(core): add thread-safe logging and unify time source to GetTickCount64

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -6,6 +6,9 @@
 #include <string.h>
 #include <time.h>
 
+// SRWLOCK for thread-safe logging (Item 7) - statically initialized, Vista+ compatible
+static SRWLOCK g_log_lock = SRWLOCK_INIT;
+
 NoSleep* nosleep_create(void) {
     NoSleep* ns = (NoSleep*)malloc(sizeof(NoSleep));
     if (!ns) return NULL;
@@ -79,13 +82,10 @@ bool nosleep_allow_sleep(NoSleep* ns) {
     return result != 0;
 }
 
-static double get_elapsed_seconds(DWORD start_tick) {
-    DWORD current_tick = GetTickCount();
-    // Handle tick counter wrap-around (every 49.7 days)
-    if (current_tick < start_tick) {
-        return (double)((0xFFFFFFFF - start_tick) + current_tick) / 1000.0;
-    }
-    return (double)(current_tick - start_tick) / 1000.0;
+static double get_elapsed_seconds(ULONGLONG start_tick64) {
+    ULONGLONG current_tick64 = GetTickCount64();
+    // GetTickCount64 does not wrap for ~584 million years, no wrap handling needed
+    return (double)(current_tick64 - start_tick64) / 1000.0;
 }
 
 int nosleep_run(NoSleep* ns, int duration_minutes, int interval_seconds, 
@@ -94,8 +94,7 @@ int nosleep_run(NoSleep* ns, int duration_minutes, int interval_seconds,
     if (!ns) return 1;
     
     ns->running = true;
-    ns->start_tick = GetTickCount();
-    GetSystemTime(&ns->start_time);
+    ns->start_tick64 = GetTickCount64();
     ns->refresh_count = 0;
     ns->failure_count = 0;
     
@@ -104,25 +103,14 @@ int nosleep_run(NoSleep* ns, int duration_minutes, int interval_seconds,
     nosleep_log_info("nosleep started - preventing system sleep");
     printf("Press Ctrl+C to stop and allow sleep\n");
     
-    SYSTEMTIME end_time;
     if (duration_minutes > 0) {
-        FILETIME ft_start, ft_end;
-        SystemTimeToFileTime(&ns->start_time, &ft_start);
-        
-        ULARGE_INTEGER uli;
-        uli.LowPart = ft_start.dwLowDateTime;
-        uli.HighPart = ft_start.dwHighDateTime;
-        
-        // Add duration in minutes (converted to 100-nanosecond intervals)
-        uli.QuadPart += (ULONGLONG)duration_minutes * 60 * 10000000LL;
-        
-        ft_end.dwLowDateTime = uli.LowPart;
-        ft_end.dwHighDateTime = uli.HighPart;
-        FileTimeToSystemTime(&ft_end, &end_time);
-        
+        // Compute approximate end time for display using time() (UTC)
+        time_t rawtime;
+        time(&rawtime);
+        rawtime += (time_t)duration_minutes * 60;
+        struct tm* end_tm = gmtime(&rawtime);
         char time_str[64];
-        sprintf(time_str, "%02d:%02d:%02d", 
-                end_time.wHour, end_time.wMinute, end_time.wSecond);
+        strftime(time_str, sizeof(time_str), "%H:%M:%S", end_tm);
         nosleep_log_info("Will run for %d minutes (until %s)", duration_minutes, time_str);
     }
     
@@ -148,7 +136,7 @@ int nosleep_run(NoSleep* ns, int duration_minutes, int interval_seconds,
         if (success) {
             ns->failure_count = 0; // Reset failure count on success
             
-            double elapsed = get_elapsed_seconds(ns->start_tick);
+            double elapsed = get_elapsed_seconds(ns->start_tick64);
             int minutes = (int)(elapsed / 60);
             int seconds = (int)(elapsed) % 60;
             
@@ -183,17 +171,11 @@ int nosleep_run(NoSleep* ns, int duration_minutes, int interval_seconds,
             break;
         }
         
-        // Check if duration has elapsed
+        // Check if duration has elapsed (using GetTickCount64, no wrap issues)
         if (duration_minutes > 0) {
-            SYSTEMTIME now;
-            GetSystemTime(&now);
-            
-            FILETIME ft_now, ft_end;
-            SystemTimeToFileTime(&now, &ft_now);
-            SystemTimeToFileTime(&end_time, &ft_end);
-            
-            // Compare FILETIMEs
-            if (CompareFileTime(&ft_now, &ft_end) >= 0) {
+            ULONGLONG elapsed_ms = GetTickCount64() - ns->start_tick64;
+            ULONGLONG duration_ms = (ULONGLONG)duration_minutes * 60 * 1000;
+            if (elapsed_ms >= duration_ms) {
                 nosleep_log_info("Duration reached (%d minutes). Stopping...", duration_minutes);
                 break;
             }
@@ -217,7 +199,7 @@ void nosleep_stop(NoSleep* ns) {
             nosleep_log_warning("Failed to restore sleep behavior");
         }
         
-        double elapsed = get_elapsed_seconds(ns->start_tick);
+        double elapsed = get_elapsed_seconds(ns->start_tick64);
         int hours = (int)(elapsed / 3600);
         int minutes = (int)((elapsed - hours * 3600) / 60);
         int seconds = (int)(elapsed) % 60;
@@ -230,8 +212,10 @@ void nosleep_stop(NoSleep* ns) {
     }
 }
 
-// Logging functions
+// Logging functions - all protected by SRWLOCK for thread safety
 void nosleep_log_info(const char* format, ...) {
+    AcquireSRWLockExclusive(&g_log_lock);
+    
     SYSTEMTIME now;
     GetSystemTime(&now);
     
@@ -243,9 +227,13 @@ void nosleep_log_info(const char* format, ...) {
     printf("\n");
     
     va_end(args);
+    
+    ReleaseSRWLockExclusive(&g_log_lock);
 }
 
 void nosleep_log_warning(const char* format, ...) {
+    AcquireSRWLockExclusive(&g_log_lock);
+    
     SYSTEMTIME now;
     GetSystemTime(&now);
     
@@ -257,9 +245,13 @@ void nosleep_log_warning(const char* format, ...) {
     printf("\n");
     
     va_end(args);
+    
+    ReleaseSRWLockExclusive(&g_log_lock);
 }
 
 void nosleep_log_error(const char* format, ...) {
+    AcquireSRWLockExclusive(&g_log_lock);
+    
     SYSTEMTIME now;
     GetSystemTime(&now);
     
@@ -271,4 +263,6 @@ void nosleep_log_error(const char* format, ...) {
     printf("\n");
     
     va_end(args);
+    
+    ReleaseSRWLockExclusive(&g_log_lock);
 }

--- a/src/core.h
+++ b/src/core.h
@@ -2,6 +2,10 @@
 #ifndef CORE_H
 #define CORE_H
 
+// Require Windows Vista+ APIs (GetTickCount64, SRWLOCK, etc.)
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
 #include <windows.h>
 #include <stdbool.h>
 
@@ -13,9 +17,8 @@
 
 typedef struct NoSleep {
     bool running;
-    SYSTEMTIME start_time;
-    DWORD start_tick;
     HANDLE stop_event;
+    ULONGLONG start_tick64;
     int refresh_count;
     int failure_count;
 } NoSleep;

--- a/test_core_log_time.sh
+++ b/test_core_log_time.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# Test: Core logging thread safety and time source unification
+set -euo pipefail
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS+1)); echo "PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+
+# Create a temp dir
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+CC="${CC:-gcc}"
+CFLAGS="-std=c99 -Wall -Wextra -O0 -g -Isrc -DVERSION_STR=\"test\""
+LIBS="-lkernel32 -luser32"
+
+SRCDIR="src"
+OBJDIR="$TMPDIR/obj"
+
+echo "=== Test Suite: Core logging + time source ==="
+echo ""
+
+# ==========================================
+# Test 1: Multi-threaded logging safety
+# ==========================================
+echo "--- Test 1: Multi-threaded logging safety ---"
+
+# Compile core.o from source for the test
+mkdir -p "$OBJDIR"
+$CC $CFLAGS -c "$SRCDIR/core.c" -o "$OBJDIR/core_test.o" 2>&1
+
+cat > "$TMPDIR/test_log_lock.c" << 'TESTEOF'
+#define _WIN32_WINNT 0x0600
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "core.h"
+
+#define THREAD_COUNT 8
+#define LOGS_PER_THREAD 30
+
+typedef struct {
+    int thread_id;
+    int logs_done;
+    bool has_error;
+} ThreadData;
+
+DWORD WINAPI log_thread(LPVOID lpParam) {
+    ThreadData* td = (ThreadData*)lpParam;
+    for (int i = 0; i < LOGS_PER_THREAD; i++) {
+        nosleep_log_info("Thread %d iteration %d", td->thread_id, i);
+        nosleep_log_warning("Thread %d warning %d", td->thread_id, i);
+        nosleep_log_error("Thread %d error %d", td->thread_id, i);
+        td->logs_done++;
+        
+        // Yield to increase chance of interleaving
+        if (i % 5 == 0) {
+            Sleep(0);
+        }
+    }
+    return 0;
+}
+
+int main(void) {
+    int exit_code = 0;
+    
+    printf("=== Testing basic logging functions ===\n");
+    nosleep_log_info("Test info message");
+    nosleep_log_warning("Test warning message");
+    nosleep_log_error("Test error message");
+    printf("=== Basic logging OK ===\n");
+    
+    // Now test multi-threaded logging
+    printf("\n=== Testing multi-threaded logging (%d threads, %d logs each) ===\n",
+           THREAD_COUNT, LOGS_PER_THREAD * 3);
+    
+    HANDLE threads[THREAD_COUNT];
+    ThreadData thread_data[THREAD_COUNT];
+    
+    for (int i = 0; i < THREAD_COUNT; i++) {
+        thread_data[i].thread_id = i;
+        thread_data[i].logs_done = 0;
+        thread_data[i].has_error = false;
+        threads[i] = CreateThread(NULL, 0, log_thread, &thread_data[i], 0, NULL);
+        if (!threads[i]) {
+            printf("FAIL: Failed to create thread %d\n", i);
+            exit_code = 1;
+        }
+    }
+    
+    // Wait for all threads to complete
+    DWORD wait_result = WaitForMultipleObjects(THREAD_COUNT, threads, TRUE, 30000);
+    if (wait_result == WAIT_TIMEOUT) {
+        printf("FAIL: Threads timed out\n");
+        exit_code = 1;
+    }
+    
+    // Check all threads completed
+    int total_logs = 0;
+    for (int i = 0; i < THREAD_COUNT; i++) {
+        CloseHandle(threads[i]);
+        total_logs += thread_data[i].logs_done;
+    }
+    
+    int expected_iterations = THREAD_COUNT * LOGS_PER_THREAD;
+    if (total_logs == expected_iterations) {
+        printf("PASS: All %d threads completed %d iterations (%d log calls total)\n", 
+               THREAD_COUNT, total_logs, total_logs * 3);
+    } else {
+        printf("FAIL: Expected %d iteration completions, got %d\n", expected_iterations, total_logs);
+        exit_code = 1;
+    }
+    
+    // The critical section protection ensures that:
+    // 1. All printf calls within a single nosleep_log_* call are atomic
+    // 2. No two threads can interleave their log output
+    // 3. No crash occurs under concurrent logging load
+    // We verify by checking the functions don't crash when called concurrently.
+    // Complete line integrity would need stdout capture which is complex here.
+    
+    if (exit_code == 0) {
+        printf("\nPASS: Multi-threaded logging completed without crash\n");
+    } else {
+        printf("\nFAIL: Multi-threaded logging test failed\n");
+    }
+    
+    return exit_code;
+}
+TESTEOF
+
+if $CC $CFLAGS "$TMPDIR/test_log_lock.c" "$OBJDIR/core_test.o" -o "$TMPDIR/test_log_lock.exe" $LIBS 2>&1; then
+    # Run the test - redirect stdout to analyze output integrity
+    "$TMPDIR/test_log_lock.exe" 2>&1
+    if [ $? -eq 0 ]; then
+        pass "Test 1: Multi-threaded logging completed without crash"
+    else
+        fail "Test 1: Multi-threaded logging test failed"
+    fi
+else
+    fail "Test 1: Compilation failed"
+fi
+
+# ==========================================
+# Test 2: GetTickCount64 time source
+# ==========================================
+echo ""
+echo "--- Test 2: GetTickCount64 time source (standalone) ---"
+
+cat > "$TMPDIR/test_tickcount64.c" << 'TESTEOF'
+#define _WIN32_WINNT 0x0600
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+// Simulate the get_elapsed_seconds function using GetTickCount64
+static double get_elapsed_seconds(ULONGLONG start_tick64) {
+    ULONGLONG current_tick64 = GetTickCount64();
+    return (double)(current_tick64 - start_tick64) / 1000.0;
+}
+
+int main(void) {
+    int failures = 0;
+    
+    printf("=== Testing GetTickCount64 elapsed time ===\n");
+    
+    // Test 1: Basic elapsed time measurement
+    ULONGLONG start = GetTickCount64();
+    Sleep(100);
+    double elapsed = get_elapsed_seconds(start);
+    
+    if (elapsed >= 0.08 && elapsed <= 0.5) {
+        printf("PASS: Basic elapsed time: %.3f s (expected ~0.1)\n", elapsed);
+    } else {
+        printf("FAIL: Basic elapsed time: %.3f s\n", elapsed);
+        failures++;
+    }
+    
+    // Test 2: Longer elapsed time
+    start = GetTickCount64();
+    Sleep(500);
+    elapsed = get_elapsed_seconds(start);
+    
+    if (elapsed >= 0.4 && elapsed <= 1.0) {
+        printf("PASS: Longer elapsed time: %.3f s (expected ~0.5)\n", elapsed);
+    } else {
+        printf("FAIL: Longer elapsed time: %.3f s\n", elapsed);
+        failures++;
+    }
+    
+    // Test 3: GetTickCount64 monotonic property
+    ULONGLONG t1 = GetTickCount64();
+    ULONGLONG t2 = GetTickCount64();
+    ULONGLONG t3 = GetTickCount64();
+    
+    if (t1 <= t2 && t2 <= t3) {
+        printf("PASS: Monotonic (%llu <= %llu <= %llu)\n", t1, t2, t3);
+    } else {
+        printf("FAIL: NOT monotonic (%llu, %llu, %llu)\n", t1, t2, t3);
+        failures++;
+    }
+    
+    // Test 4: Large values (no 32-bit wrap)
+    ULONGLONG tick = GetTickCount64();
+    printf("INFO: GetTickCount64 = %llu ms (uptime)\n", tick);
+    if (tick < 0xFFFFFFFFLL) {
+        printf("INFO: Value fits in 32-bit (system recently booted)\n");
+    } else {
+        printf("PASS: Value exceeds 32-bit range (no wrap issue)\n");
+    }
+    
+    // Test 5: Duration check simulation
+    ULONGLONG start_tick = GetTickCount64();
+    ULONGLONG duration_ms = 200;
+    
+    Sleep(100);
+    ULONGLONG elapsed_ms = GetTickCount64() - start_tick;
+    if (elapsed_ms < duration_ms) {
+        printf("PASS: Duration NOT yet reached: %llums < %llums\n", elapsed_ms, duration_ms);
+    } else {
+        printf("FAIL: Duration unexpectedly reached\n");
+        failures++;
+    }
+    
+    Sleep(150);
+    elapsed_ms = GetTickCount64() - start_tick;
+    if (elapsed_ms >= duration_ms) {
+        printf("PASS: Duration reached: %llums >= %llums\n", elapsed_ms, duration_ms);
+    } else {
+        printf("FAIL: Duration NOT reached\n");
+        failures++;
+    }
+    
+    // Test 6: Large duration (no overflow)
+    ULONGLONG big_duration = (ULONGLONG)24 * 60 * 60 * 1000; // 24 hours
+    ULONGLONG calc = start_tick + big_duration;
+    if (calc > start_tick) {
+        printf("PASS: Large duration (24h) calculation: %llu + %llu > %llu\n",
+               start_tick, big_duration, calc);
+    } else {
+        printf("FAIL: Large duration overflow\n");
+        failures++;
+    }
+    
+    printf("\n=== Failures: %d ===\n", failures);
+    return failures > 0 ? 1 : 0;
+}
+TESTEOF
+
+if $CC $CFLAGS "$TMPDIR/test_tickcount64.c" -o "$TMPDIR/test_tickcount64.exe" -lkernel32 2>&1; then
+    if "$TMPDIR/test_tickcount64.exe" 2>&1; then
+        pass "Test 2: GetTickCount64 time source works correctly"
+    else
+        fail "Test 2: GetTickCount64 test failed"
+    fi
+else
+    fail "Test 2: Compilation failed"
+fi
+
+# ==========================================
+# Summary
+# ==========================================
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What this PR does

Item 7 - 内核线程无日志保护: Add SRWLOCK protection to nosleep_log_* functions for thread-safe multi-threaded logging output.

Item 9 - nosleep_run 重复的时间源: Unify time calculations to GetTickCount64(), removing redundant GetTickCount() and GetSystemTime/FileTime calculations.

### Before this PR:
- Log output from multiple threads could interleave/corrupt each other's lines
- Time calculation used both GetTickCount() (32-bit, wraps every ~49.7 days) and GetSystemTime + FileTime for duration checking
- No _WIN32_WINNT definition for Vista+ API availability

### After this PR:
- Each nosleep_log_* call is atomic under SRWLOCK - no interleaved log lines
- All time calculations use GetTickCount64() (64-bit, no wrap)
- Simplified duration checking: single GetTickCount64() call
- Removed start_time field from NoSleep struct
- _WIN32_WINNT=0x0600 defined in core.h for Vista+ APIs

### Type of change
fix

### Breaking changes (if any)
None. The NoSleep struct changed (removed start_time, renamed start_tick to start_tick64) but all access is through API functions.
